### PR TITLE
Manual decommission if dc_util not present

### DIFF
--- a/debug_cluster.py
+++ b/debug_cluster.py
@@ -1,0 +1,356 @@
+#!/usr/bin/env python3
+"""
+Debug script to inspect CrateDB cluster configuration and understand
+why prestop hook detection or health checks are failing.
+
+Usage:
+    python debug_cluster.py --cluster-name aqua-darth-vader --namespace default
+"""
+
+import argparse
+import json
+import sys
+from kubernetes import client, config
+from kubernetes.client.exceptions import ApiException
+
+
+def load_kube_config():
+    """Load Kubernetes configuration."""
+    try:
+        config.load_incluster_config()
+        print("✅ Loaded in-cluster config")
+    except Exception:
+        try:
+            config.load_kube_config()
+            print("✅ Loaded kubeconfig")
+        except Exception as e:
+            print(f"❌ Failed to load kubeconfig: {e}")
+            sys.exit(1)
+
+
+def find_statefulset(apps_v1, cluster_name, namespace):
+    """Find the StatefulSet for a CrateDB cluster."""
+    possible_patterns = [
+        f"crate-data-hot-{cluster_name}",
+        f"crate-{cluster_name}",
+        f"{cluster_name}",
+    ]
+
+    print(f"\n🔍 Searching for StatefulSet with patterns: {possible_patterns}")
+    
+    for pattern in possible_patterns:
+        try:
+            sts = apps_v1.read_namespaced_stateful_set(name=pattern, namespace=namespace)
+            print(f"✅ Found StatefulSet: {pattern}")
+            return pattern, sts
+        except ApiException as e:
+            if e.status == 404:
+                print(f"   - {pattern}: Not found")
+            else:
+                print(f"   - {pattern}: Error - {e}")
+    
+    # List all StatefulSets to help debug
+    try:
+        sts_list = apps_v1.list_namespaced_stateful_set(namespace=namespace)
+        print(f"\n📋 Available StatefulSets in namespace {namespace}:")
+        for sts in sts_list.items:
+            print(f"   - {sts.metadata.name}")
+    except Exception as e:
+        print(f"❌ Failed to list StatefulSets: {e}")
+    
+    return None, None
+
+
+def analyze_prestop_hook(sts, cluster_name):
+    """Analyze prestop hook configuration."""
+    print(f"\n🔍 Analyzing preStop hook for {cluster_name}")
+    
+    if not sts.spec.template.spec.containers:
+        print("❌ No containers found in StatefulSet")
+        return False, False, 720
+    
+    print(f"📦 Found {len(sts.spec.template.spec.containers)} containers:")
+    
+    has_prestop_hook = False
+    has_dc_util = False
+    dc_util_timeout = 720
+    
+    for container in sts.spec.template.spec.containers:
+        print(f"   - Container: {container.name}")
+        
+        if container.name == "crate":
+            print(f"     ✅ Found crate container")
+            
+            if container.lifecycle:
+                print(f"     ✅ Has lifecycle configuration")
+                
+                if container.lifecycle.pre_stop:
+                    print(f"     ✅ Has preStop hook")
+                    has_prestop_hook = True
+                    
+                    # Check exec attribute
+                    exec_attr = getattr(container.lifecycle.pre_stop, "exec", None)
+                    print(f"     📝 preStop exec: {exec_attr}")
+                    
+                    if exec_attr and exec_attr.command:
+                        print(f"     📝 preStop command: {exec_attr.command}")
+                        
+                        # Extract shell command
+                        cmd = exec_attr.command
+                        if len(cmd) >= 3 and cmd[0] in ["/bin/sh", "/bin/bash"] and cmd[1] == "-c":
+                            shell_command = str(cmd[2])
+                        else:
+                            shell_command = " ".join(str(c) for c in cmd if c is not None)
+                        
+                        print(f"     📝 Shell command: {shell_command}")
+                        
+                        # Check for dc_util patterns
+                        decomm_patterns = ["dc_util", "dc-util", "dcutil", "decommission", "decomm", "/dc_util-", "/dc-util-"]
+                        found_patterns = [p for p in decomm_patterns if p in shell_command]
+                        
+                        if found_patterns:
+                            has_dc_util = True
+                            print(f"     ✅ Found decommission patterns: {found_patterns}")
+                            
+                            # Extract timeout
+                            import re
+                            timeout_patterns = [
+                                r"(?:--|-)(?:timeout|t)\s*(?:=|\s+)(\d+)([smh]?)",
+                                r"timeout\s+(\d+)([smh]?)",
+                                r"-min-availability\s+\w+\s+-timeout\s+(\d+)([smh]?)",
+                            ]
+                            
+                            for pattern in timeout_patterns:
+                                match = re.search(pattern, shell_command)
+                                if match:
+                                    value = int(match.group(1))
+                                    unit = match.group(2) if len(match.groups()) > 1 else ""
+                                    
+                                    if unit == "m":
+                                        timeout = value * 60
+                                    elif unit == "h":
+                                        timeout = value * 3600
+                                    else:
+                                        timeout = value
+                                    
+                                    dc_util_timeout = timeout
+                                    print(f"     ⏱️  Extracted timeout: {timeout}s")
+                                    break
+                        else:
+                            print(f"     ❌ No decommission patterns found")
+                    else:
+                        print(f"     ❌ No command in preStop exec")
+                else:
+                    print(f"     ❌ No preStop hook")
+            else:
+                print(f"     ❌ No lifecycle configuration")
+    
+    print(f"\n📊 PreStop Analysis Results:")
+    print(f"   - has_prestop_hook: {has_prestop_hook}")
+    print(f"   - has_dc_util: {has_dc_util}")
+    print(f"   - dc_util_timeout: {dc_util_timeout}")
+    
+    return has_prestop_hook, has_dc_util, dc_util_timeout
+
+
+def find_cratedb_crd(custom_api, cluster_name, namespace):
+    """Find the CrateDB CRD."""
+    print(f"\n🔍 Searching for CrateDB CRD")
+    
+    possible_patterns = [
+        cluster_name,
+        f"crate-{cluster_name}",
+        f"{cluster_name}-crate",
+    ]
+    
+    for pattern in possible_patterns:
+        try:
+            crd = custom_api.get_namespaced_custom_object(
+                group="cloud.crate.io",
+                version="v1",
+                namespace=namespace,
+                plural="cratedbs",
+                name=pattern,
+            )
+            print(f"✅ Found CrateDB CRD: {pattern}")
+            return pattern, crd
+        except ApiException as e:
+            if e.status == 404:
+                print(f"   - {pattern}: Not found")
+            else:
+                print(f"   - {pattern}: Error - {e}")
+    
+    # List all CrateDB CRDs
+    try:
+        crd_list = custom_api.list_namespaced_custom_object(
+            group="cloud.crate.io",
+            version="v1",
+            namespace=namespace,
+            plural="cratedbs"
+        )
+        print(f"\n📋 Available CrateDB CRDs in namespace {namespace}:")
+        for item in crd_list.get("items", []):
+            name = item.get("metadata", {}).get("name", "unknown")
+            print(f"   - {name}")
+    except Exception as e:
+        print(f"❌ Failed to list CrateDB CRDs: {e}")
+    
+    return None, None
+
+
+def analyze_cluster_health(crd):
+    """Analyze cluster health from CRD."""
+    print(f"\n🏥 Analyzing cluster health")
+    
+    if not crd:
+        print("❌ No CRD available")
+        return "UNKNOWN"
+    
+    status = crd.get("status", {})
+    print(f"📝 CRD status: {json.dumps(status, indent=2)}")
+    
+    # Try different health extraction methods
+    health_sources = [
+        ("status.crateDBStatus.health", status.get("crateDBStatus", {}).get("health")),
+        ("status.health", status.get("health")),
+        ("spec.cluster.health", crd.get("spec", {}).get("cluster", {}).get("health")),
+    ]
+    
+    print(f"\n🔍 Health sources:")
+    for source, value in health_sources:
+        print(f"   - {source}: {value}")
+    
+    # Use the first non-None value
+    for source, health in health_sources:
+        if health:
+            print(f"✅ Using health from {source}: {health}")
+            return health
+    
+    print(f"❌ No health information found")
+    return "UNKNOWN"
+
+
+def get_pods(core_v1, sts_name, namespace):
+    """Get pods for the StatefulSet."""
+    print(f"\n🔍 Finding pods for StatefulSet {sts_name}")
+    
+    try:
+        pods = core_v1.list_namespaced_pod(
+            namespace=namespace,
+            label_selector=f"app=crate,statefulset={sts_name}"
+        )
+        
+        if not pods.items:
+            # Try alternative selectors
+            selectors = [
+                "app=crate",
+                f"app=crate,crate-cluster={sts_name}",
+            ]
+            
+            for selector in selectors:
+                pods = core_v1.list_namespaced_pod(
+                    namespace=namespace,
+                    label_selector=selector
+                )
+                if pods.items:
+                    print(f"✅ Found pods with selector: {selector}")
+                    break
+        
+        if pods.items:
+            print(f"📦 Found {len(pods.items)} pods:")
+            for pod in pods.items:
+                phase = pod.status.phase
+                ready = "Unknown"
+                if pod.status.container_statuses:
+                    ready_count = sum(1 for c in pod.status.container_statuses if c.ready)
+                    total_count = len(pod.status.container_statuses)
+                    ready = f"{ready_count}/{total_count}"
+                
+                print(f"   - {pod.metadata.name}: {phase} (Ready: {ready})")
+                
+                # Check for recent restarts
+                if pod.status.container_statuses:
+                    for container in pod.status.container_statuses:
+                        if container.restart_count > 0:
+                            print(f"     ⚠️  Container {container.name}: {container.restart_count} restarts")
+            
+            return [pod.metadata.name for pod in pods.items]
+        else:
+            print(f"❌ No pods found")
+            return []
+            
+    except Exception as e:
+        print(f"❌ Failed to get pods: {e}")
+        return []
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Debug CrateDB cluster configuration")
+    parser.add_argument("--cluster-name", required=True, help="Cluster name")
+    parser.add_argument("--namespace", default="default", help="Namespace (default: default)")
+    
+    args = parser.parse_args()
+    
+    print(f"🔍 Debugging cluster: {args.cluster_name} in namespace: {args.namespace}")
+    print("=" * 80)
+    
+    # Load Kubernetes config
+    load_kube_config()
+    
+    # Initialize clients
+    apps_v1 = client.AppsV1Api()
+    custom_api = client.CustomObjectsApi()
+    core_v1 = client.CoreV1Api()
+    
+    # Find StatefulSet
+    sts_name, sts = find_statefulset(apps_v1, args.cluster_name, args.namespace)
+    if not sts:
+        print(f"❌ Could not find StatefulSet for cluster {args.cluster_name}")
+        sys.exit(1)
+    
+    # Analyze preStop hook
+    has_prestop_hook, has_dc_util, dc_util_timeout = analyze_prestop_hook(sts, args.cluster_name)
+    
+    # Find CRD
+    crd_name, crd = find_cratedb_crd(custom_api, args.cluster_name, args.namespace)
+    
+    # Analyze health
+    health = analyze_cluster_health(crd)
+    
+    # Get pods
+    pods = get_pods(core_v1, sts_name, args.namespace)
+    
+    # Summary
+    print(f"\n" + "=" * 80)
+    print(f"📊 SUMMARY")
+    print(f"=" * 80)
+    print(f"Cluster Name: {args.cluster_name}")
+    print(f"Namespace: {args.namespace}")
+    print(f"StatefulSet: {sts_name}")
+    print(f"CRD Name: {crd_name}")
+    print(f"Health: {health}")
+    print(f"Pods: {len(pods)} found")
+    print(f"Has PreStop Hook: {has_prestop_hook}")
+    print(f"Has DC Util: {has_dc_util}")
+    print(f"DC Util Timeout: {dc_util_timeout}s")
+    
+    if has_dc_util:
+        print(f"\n✅ This cluster SHOULD use Kubernetes-managed decommission")
+        print(f"   - Pod deletion will trigger preStop hook")
+        print(f"   - dc_util will handle decommission automatically")
+        print(f"   - Use grace period: {dc_util_timeout + 60}s")
+    else:
+        print(f"\n⚠️  This cluster SHOULD use manual decommission")
+        print(f"   - Execute decommission commands via API")
+        print(f"   - Wait for process exit")
+        print(f"   - Then delete pod")
+    
+    if health not in ["GREEN"]:
+        print(f"\n⚠️  HEALTH ISSUE: Cluster health is {health}")
+        print(f"   - Check pod status and logs")
+        print(f"   - Verify cluster configuration")
+        print(f"   - Health checks will fail until this is resolved")
+
+
+if __name__ == "__main__":
+    main()

--- a/decommission_example.py
+++ b/decommission_example.py
@@ -1,0 +1,331 @@
+"""
+Example usage of the CrateDB decommission activity with smart strategy selection.
+
+This example demonstrates how to use the new decommission activity that automatically
+detects whether a cluster has Kubernetes-managed decommission (preStop hook with dc_util)
+or requires manual decommission.
+"""
+
+import asyncio
+import logging
+from datetime import datetime, timedelta
+
+from temporalio.client import Client
+from temporalio.worker import Worker
+
+from rr.activities import CrateDBActivities
+from rr.models import (
+    CrateDBCluster,
+    DecommissionInput,
+    RestartOptions,
+    PodRestartInput
+)
+
+# Configure logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+async def example_decommission_only():
+    """
+    Example: Decommission a pod without restart.
+    
+    This is useful when you want to gracefully remove a pod from the cluster
+    without restarting it (e.g., for cluster downsizing).
+    """
+    
+    # Example cluster with Kubernetes-managed decommission (has dc_util in preStop hook)
+    cluster_with_dc_util = CrateDBCluster(
+        name="cluster1",
+        namespace="crate-system",
+        statefulset_name="crate-data-hot-cluster1",
+        health="GREEN",
+        replicas=3,
+        pods=["crate-data-hot-cluster1-0", "crate-data-hot-cluster1-1", "crate-data-hot-cluster1-2"],
+        has_prestop_hook=True,
+        has_dc_util=True,
+        dc_util_timeout=720,
+        crd_name="cluster1"
+    )
+    
+    # Connect to Temporal
+    client = await Client.connect("localhost:7233")
+    
+    # Create decommission input
+    decommission_input = DecommissionInput(
+        pod_name="crate-data-hot-cluster1-2",  # Decommission the last pod
+        namespace="crate-system",
+        cluster=cluster_with_dc_util,
+        dry_run=False
+    )
+    
+    # Execute decommission activity
+    activities = CrateDBActivities()
+    result = await activities.decommission_pod(decommission_input)
+    
+    if result.success:
+        logger.info(f"✅ Decommission successful!")
+        logger.info(f"   Strategy used: {result.strategy_used}")
+        logger.info(f"   Duration: {result.duration:.1f}s")
+        logger.info(f"   Timeout configured: {result.decommission_timeout}s")
+    else:
+        logger.error(f"❌ Decommission failed: {result.error}")
+
+
+async def example_decommission_with_restart():
+    """
+    Example: Decommission and restart a pod.
+    
+    This shows how decommission is integrated into the normal pod restart flow.
+    """
+    
+    # Example cluster requiring manual decommission (no dc_util in preStop hook)
+    cluster_manual = CrateDBCluster(
+        name="cluster2",
+        namespace="default",
+        statefulset_name="crate-data-hot-cluster2", 
+        health="GREEN",
+        replicas=3,
+        pods=["crate-data-hot-cluster2-0", "crate-data-hot-cluster2-1", "crate-data-hot-cluster2-2"],
+        has_prestop_hook=False,
+        has_dc_util=False,
+        dc_util_timeout=720,
+        crd_name="cluster2"
+    )
+    
+    # Create restart input (includes decommission)
+    restart_input = PodRestartInput(
+        pod_name="crate-data-hot-cluster2-0",
+        namespace="default",
+        cluster=cluster_manual,
+        dry_run=False,
+        pod_ready_timeout=600
+    )
+    
+    # Execute restart (which includes smart decommission)
+    activities = CrateDBActivities()
+    result = await activities.restart_pod(restart_input)
+    
+    if result.success:
+        logger.info(f"✅ Pod restart successful!")
+        logger.info(f"   Duration: {result.duration:.1f}s")
+        logger.info(f"   Pod was decommissioned and restarted")
+    else:
+        logger.error(f"❌ Pod restart failed: {result.error}")
+
+
+async def example_compare_strategies():
+    """
+    Example: Compare both decommission strategies side by side.
+    """
+    
+    clusters = [
+        # Kubernetes-managed decommission
+        CrateDBCluster(
+            name="k8s-managed",
+            namespace="crate-system", 
+            statefulset_name="crate-data-hot-k8s-managed",
+            health="GREEN",
+            replicas=3,
+            pods=["crate-data-hot-k8s-managed-0"],
+            has_prestop_hook=True,
+            has_dc_util=True,
+            dc_util_timeout=600,
+            crd_name="k8s-managed"
+        ),
+        # Manual decommission
+        CrateDBCluster(
+            name="manual",
+            namespace="default",
+            statefulset_name="crate-data-hot-manual",
+            health="GREEN", 
+            replicas=3,
+            pods=["crate-data-hot-manual-0"],
+            has_prestop_hook=False,
+            has_dc_util=False,
+            dc_util_timeout=720,
+            crd_name="manual"
+        )
+    ]
+    
+    activities = CrateDBActivities()
+    
+    for cluster in clusters:
+        logger.info(f"\n=== Testing {cluster.name} cluster ===")
+        logger.info(f"Has preStop hook: {cluster.has_prestop_hook}")
+        logger.info(f"Has dc_util: {cluster.has_dc_util}")
+        logger.info(f"Timeout: {cluster.dc_util_timeout}s")
+        
+        decommission_input = DecommissionInput(
+            pod_name=cluster.pods[0],
+            namespace=cluster.namespace,
+            cluster=cluster,
+            dry_run=True  # Dry run for demonstration
+        )
+        
+        result = await activities.decommission_pod(decommission_input)
+        
+        logger.info(f"Strategy selected: {result.strategy_used}")
+        logger.info(f"Would succeed: {result.success}")
+
+
+async def example_error_handling():
+    """
+    Example: Proper error handling for decommission operations.
+    """
+    
+    # Cluster with invalid configuration (for demonstration)
+    invalid_cluster = CrateDBCluster(
+        name="invalid",
+        namespace="nonexistent",
+        statefulset_name="does-not-exist",
+        health="RED",
+        replicas=0,
+        pods=["nonexistent-pod-0"],
+        has_prestop_hook=False,
+        has_dc_util=False,
+        dc_util_timeout=720,
+        crd_name="invalid"
+    )
+    
+    decommission_input = DecommissionInput(
+        pod_name="nonexistent-pod-0",
+        namespace="nonexistent", 
+        cluster=invalid_cluster,
+        dry_run=False
+    )
+    
+    activities = CrateDBActivities()
+    
+    try:
+        result = await activities.decommission_pod(decommission_input)
+        
+        if not result.success:
+            logger.error(f"Decommission failed as expected: {result.error}")
+            logger.info(f"Duration before failure: {result.duration:.1f}s")
+            logger.info(f"Strategy attempted: {result.strategy_used}")
+            
+            # Handle the error appropriately
+            if "not found" in result.error.lower():
+                logger.info("Pod or namespace does not exist")
+            elif "timeout" in result.error.lower():
+                logger.info("Operation timed out - cluster may be unhealthy")
+            else:
+                logger.info("Unknown error - requires investigation")
+                
+    except Exception as e:
+        logger.error(f"Unexpected exception during decommission: {e}")
+
+
+async def example_batch_decommission():
+    """
+    Example: Decommission multiple pods in sequence.
+    
+    This shows how to gracefully decommission multiple pods while maintaining
+    cluster health and data availability.
+    """
+    
+    cluster = CrateDBCluster(
+        name="batch-test",
+        namespace="default",
+        statefulset_name="crate-data-hot-batch-test",
+        health="GREEN",
+        replicas=5,
+        pods=[
+            "crate-data-hot-batch-test-0",
+            "crate-data-hot-batch-test-1", 
+            "crate-data-hot-batch-test-2",
+            "crate-data-hot-batch-test-3",
+            "crate-data-hot-batch-test-4"
+        ],
+        has_prestop_hook=True,
+        has_dc_util=True,
+        dc_util_timeout=900,  # Longer timeout for larger cluster
+        crd_name="batch-test"
+    )
+    
+    activities = CrateDBActivities()
+    
+    # Decommission pods one by one (last pod first to maintain availability)
+    pods_to_decommission = cluster.pods[-2:]  # Decommission last 2 pods
+    
+    logger.info(f"Starting batch decommission of {len(pods_to_decommission)} pods")
+    
+    successful_decommissions = []
+    failed_decommissions = []
+    
+    for pod_name in pods_to_decommission:
+        logger.info(f"\n--- Decommissioning {pod_name} ---")
+        
+        decommission_input = DecommissionInput(
+            pod_name=pod_name,
+            namespace=cluster.namespace,
+            cluster=cluster,
+            dry_run=False
+        )
+        
+        try:
+            result = await activities.decommission_pod(decommission_input)
+            
+            if result.success:
+                successful_decommissions.append(pod_name)
+                logger.info(f"✅ {pod_name} decommissioned successfully in {result.duration:.1f}s")
+                
+                # Wait a bit before decommissioning next pod to allow cluster to stabilize
+                logger.info("Waiting 30s for cluster to stabilize...")
+                await asyncio.sleep(30)
+                
+            else:
+                failed_decommissions.append(pod_name)
+                logger.error(f"❌ {pod_name} decommission failed: {result.error}")
+                break  # Stop on first failure to avoid cascading issues
+                
+        except Exception as e:
+            failed_decommissions.append(pod_name)
+            logger.error(f"❌ {pod_name} decommission exception: {e}")
+            break
+    
+    # Summary
+    logger.info(f"\n=== Batch Decommission Summary ===")
+    logger.info(f"Successful: {len(successful_decommissions)} pods")
+    logger.info(f"Failed: {len(failed_decommissions)} pods")
+    
+    if successful_decommissions:
+        logger.info(f"Successfully decommissioned: {', '.join(successful_decommissions)}")
+    
+    if failed_decommissions:
+        logger.error(f"Failed to decommission: {', '.join(failed_decommissions)}")
+
+
+async def main():
+    """Run all examples."""
+    
+    logger.info("🚀 CrateDB Decommission Examples")
+    logger.info("=" * 50)
+    
+    try:
+        logger.info("\n1. Testing decommission strategy comparison...")
+        await example_compare_strategies()
+        
+        logger.info("\n2. Testing error handling...")
+        await example_error_handling()
+        
+        # Uncomment these for actual cluster operations (requires running clusters)
+        # logger.info("\n3. Testing decommission only...")
+        # await example_decommission_only()
+        # 
+        # logger.info("\n4. Testing decommission with restart...")
+        # await example_decommission_with_restart()
+        #
+        # logger.info("\n5. Testing batch decommission...")  
+        # await example_batch_decommission()
+        
+        logger.info("\n✅ All examples completed successfully!")
+        
+    except Exception as e:
+        logger.error(f"❌ Example failed: {e}")
+        raise
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/maintenance-windows.toml
+++ b/maintenance-windows.toml
@@ -1,9 +1,18 @@
 # Maintenance Windows Configuration
 # All times are in UTC
+#
+# Optional Settings:
+# - dc_util_timeout: Timeout for decommission operations in seconds (default: 720)
+# - min_availability: Required cluster availability during decommission
+#   * PRIMARIES: Keep primary shards available (default)
+#   * FULL: Keep all shards available (safest)
+#   * NONE: Allow all shards to be unavailable (fastest)
 
 [aqua-darth-vader]
 timezone = "UTC"
-min_window_duration = 30 # Minimum minutes needed for maintenance
+min_window_duration = 30       # Minimum minutes needed for maintenance
+dc_util_timeout = 720          # Timeout for dc_util in seconds (optional, defaults to 720)
+min_availability = "PRIMARIES" # PRIMARIES, NONE, or FULL (optional, defaults to PRIMARIES)
 
 [[aqua-darth-vader.windows]]
 time = "18:00-24:00"
@@ -18,6 +27,8 @@ description = "Monthly maintenance slots"
 [tgw-x]
 timezone = "UTC"
 min_window_duration = 30
+dc_util_timeout = 900     # Custom timeout for this cluster
+min_availability = "FULL" # Require full availability
 
 [[tgw-x.windows]]
 time = "18:00-19:30"
@@ -32,6 +43,8 @@ description = "Late evening window"
 [production-cluster]
 timezone = "UTC"
 min_window_duration = 60
+dc_util_timeout = 1200         # Longer timeout for production
+min_availability = "PRIMARIES"
 
 [[production-cluster.windows]]
 time = "02:00-04:00"
@@ -46,6 +59,8 @@ description = "End of month maintenance"
 [development-cluster]
 timezone = "UTC"
 min_window_duration = 15
+dc_util_timeout = 600     # Shorter timeout for dev
+min_availability = "NONE" # Less strict for development
 
 [[development-cluster.windows]]
 time = "12:00-13:00"
@@ -60,6 +75,8 @@ description = "First Monday of month"
 [staging-cluster]
 timezone = "UTC"
 min_window_duration = 45
+dc_util_timeout = 900          # Moderate timeout for staging
+min_availability = "PRIMARIES" # Standard availability for staging
 
 [[staging-cluster.windows]]
 time = "01:00-03:00"

--- a/rr/activities.py
+++ b/rr/activities.py
@@ -3,12 +3,15 @@ Temporal activities for CrateDB Kubernetes operations.
 """
 
 import asyncio
+import json
+import random
 import time
 from datetime import datetime, timezone
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 from kubernetes import client
 from kubernetes.client.exceptions import ApiException
+from kubernetes import stream
 from temporalio import activity
 
 from .kubeconfig import KubeConfigHandler
@@ -19,6 +22,8 @@ from .models import (
     ClusterValidationInput,
     ClusterValidationResult,
     CrateDBCluster,
+    DecommissionInput,
+    DecommissionResult,
     HealthCheckInput,
     HealthCheckResult,
     MaintenanceWindowCheckInput,
@@ -26,6 +31,7 @@ from .models import (
     PodRestartInput,
     PodRestartResult,
 )
+from .maintenance_windows import MaintenanceWindowChecker
 
 
 class CrateDBActivities:
@@ -70,7 +76,7 @@ class CrateDBActivities:
                 # Get all namespaces first
                 namespaces = self.core_v1.list_namespace()
                 all_crds = {"items": []}
-                
+
                 for namespace in namespaces.items:
                     try:
                         crds = self.custom_api.list_namespaced_custom_object(
@@ -83,9 +89,9 @@ class CrateDBActivities:
                     except ApiException as ns_e:
                         if ns_e.status != 404:  # Ignore 404s for individual namespaces
                             activity.logger.warning(f"Error querying namespace {namespace.metadata.name}: {ns_e}")
-                
+
                 crds = all_crds
-                
+
             except ApiException as e:
                 if e.status == 404:
                     error_msg = "CrateDB CRD not found. Is the CrateDB operator installed?"
@@ -98,7 +104,7 @@ class CrateDBActivities:
 
             for item in crds.get("items", []):
                 try:
-                    cluster = await self._process_crd_item(item, input_data.cluster_names)
+                    cluster = await self._process_crd_item(item, input_data.cluster_names, input_data.maintenance_config_path)
                     if cluster:
                         clusters.append(cluster)
                 except Exception as e:
@@ -114,7 +120,7 @@ class CrateDBActivities:
             activity.logger.error(error_msg)
             return ClusterDiscoveryResult(clusters=[], total_found=0, errors=[error_msg])
 
-    async def _process_crd_item(self, item: dict, filter_names: Optional[List[str]]) -> Optional[CrateDBCluster]:
+    async def _process_crd_item(self, item: dict, filter_names: Optional[List[str]], maintenance_config_path: Optional[str] = None) -> Optional[CrateDBCluster]:
         """Process a single CRD item and return CrateDBCluster if it matches criteria."""
         crd_name = item["metadata"]["name"]
         namespace = item["metadata"]["namespace"]
@@ -143,6 +149,21 @@ class CrateDBActivities:
         # Find pods
         pods = await self._find_pods(namespace, sts_name, crd_name, cluster_name)
 
+        # Default values
+        min_availability = "PRIMARIES"
+
+        # Apply maintenance configuration overrides if available
+        if maintenance_config_path:
+            try:
+                checker = MaintenanceWindowChecker(maintenance_config_path)
+                config = checker.get_cluster_config(cluster_name)
+                if config:
+                    dc_util_timeout = config.dc_util_timeout
+                    min_availability = config.min_availability
+                    activity.logger.info(f"Applied maintenance config for {cluster_name}: dc_util_timeout={dc_util_timeout}, min_availability={min_availability}")
+            except Exception as e:
+                activity.logger.warning(f"Failed to load maintenance config for {cluster_name}: {e}")
+
         return CrateDBCluster(
             name=cluster_name,
             namespace=namespace,
@@ -155,6 +176,7 @@ class CrateDBActivities:
             suspended=sts.spec.replicas == 0,
             crd_name=crd_name,
             dc_util_timeout=dc_util_timeout,
+            min_availability=min_availability,
         )
 
     async def _find_statefulset(self, crd_name: str, cluster_name: str, namespace: str):
@@ -195,29 +217,59 @@ class CrateDBActivities:
         has_dc_util = False
         dc_util_timeout = 720
 
+        activity.logger.debug(f"Analyzing prestop hook for {cluster_name}")
+        activity.logger.debug(f"StatefulSet has {len(sts.spec.template.spec.containers) if sts.spec.template.spec.containers else 0} containers")
+
         if not sts.spec.template.spec.containers:
+            activity.logger.debug(f"No containers found in StatefulSet {cluster_name}")
             return has_prestop_hook, has_dc_util, dc_util_timeout
 
         for container in sts.spec.template.spec.containers:
-            if container.name == "crate" and container.lifecycle and container.lifecycle.pre_stop:
-                has_prestop_hook = True
+            activity.logger.debug(f"Checking container: {container.name}")
 
-                try:
-                    # Check for decommissioning utility
-                    exec_attr = getattr(container.lifecycle.pre_stop, "exec", None) or \
-                               getattr(container.lifecycle.pre_stop, "_exec", None)
+            if container.name == "crate":
+                activity.logger.debug(f"Found crate container for {cluster_name}")
 
-                    if exec_attr:
-                        cmd = getattr(exec_attr, "command", None) or \
-                              getattr(exec_attr, "_command", None)
+                if container.lifecycle:
+                    activity.logger.debug(f"Container has lifecycle configuration")
 
-                        if cmd:
-                            shell_command = self._extract_shell_command(cmd)
-                            has_dc_util, dc_util_timeout = self._check_decommission_utility(shell_command, cluster_name)
+                    if container.lifecycle.pre_stop:
+                        activity.logger.debug(f"Container has preStop hook")
+                        has_prestop_hook = True
 
-                except Exception as e:
-                    activity.logger.warning(f"Error analyzing prestop hook for {cluster_name}: {e}")
+                        try:
+                            # Check for decommissioning utility
+                            exec_attr = getattr(container.lifecycle.pre_stop, "exec", None) or \
+                                       getattr(container.lifecycle.pre_stop, "_exec", None)
 
+                            activity.logger.debug(f"preStop exec attribute: {exec_attr}")
+
+                            if exec_attr:
+                                cmd = getattr(exec_attr, "command", None) or \
+                                      getattr(exec_attr, "_command", None)
+
+                                activity.logger.debug(f"preStop command: {cmd}")
+
+                                if cmd:
+                                    shell_command = self._extract_shell_command(cmd)
+                                    activity.logger.debug(f"Extracted shell command: {shell_command}")
+                                    has_dc_util, dc_util_timeout = self._check_decommission_utility(shell_command, cluster_name)
+                                    activity.logger.debug(f"dc_util detection result: has_dc_util={has_dc_util}, timeout={dc_util_timeout}")
+                                else:
+                                    activity.logger.debug(f"No command found in preStop exec")
+                            else:
+                                activity.logger.debug(f"No exec attribute found in preStop hook")
+
+                        except Exception as e:
+                            activity.logger.warning(f"Error analyzing prestop hook for {cluster_name}: {e}")
+                    else:
+                        activity.logger.debug(f"Container has lifecycle but no preStop hook")
+                else:
+                    activity.logger.debug(f"Container has no lifecycle configuration")
+            else:
+                activity.logger.debug(f"Skipping non-crate container: {container.name}")
+
+        activity.logger.info(f"Final prestop analysis for {cluster_name}: has_prestop_hook={has_prestop_hook}, has_dc_util={has_dc_util}, timeout={dc_util_timeout}")
         return has_prestop_hook, has_dc_util, dc_util_timeout
 
     def _extract_shell_command(self, cmd: List[str]) -> str:
@@ -354,15 +406,116 @@ class CrateDBActivities:
                     completed_at=None,
                 )
 
-            activity.logger.info(f"Restarting pod {input_data.pod_name}")
+            activity.logger.info(f"Starting decommission and restart for pod {input_data.pod_name}")
 
-            # Delete the pod
-            self.core_v1.delete_namespaced_pod(
-                name=input_data.pod_name,
-                namespace=input_data.namespace
+            # CRITICAL: Validate cluster health before proceeding with pod restart
+            # This prevents pods from being deleted when cluster is not GREEN
+            activity.logger.info(f"Validating cluster health before restarting pod {input_data.pod_name}")
+            
+            # Retry health check with exponential backoff (state-based attempts)
+            # Default max attempts - will be overridden based on health state
+            max_attempts = 30
+            base_delay = 2.0  # Start with 2 seconds
+            max_delay = 30.0  # Cap at 30 seconds to keep total time reasonable
+            
+            # Track attempts per health state
+            attempt = 0
+            while attempt < max_attempts:
+                try:
+                    health_result = await self.check_cluster_health(
+                        HealthCheckInput(
+                            cluster=input_data.cluster,
+                            dry_run=input_data.dry_run,
+                            timeout=30,
+                        )
+                    )
+                    
+                    if health_result.is_healthy and health_result.health_status == "GREEN":
+                        activity.logger.info(f"Cluster health is GREEN, proceeding with pod restart for {input_data.pod_name}")
+                        break  # Health is good, proceed with restart
+                    else:
+                        # Determine max attempts based on health state
+                        if health_result.health_status == "YELLOW":
+                            state_max_attempts = 30
+                        elif health_result.health_status == "RED":
+                            state_max_attempts = 30
+                        elif health_result.health_status == "UNKNOWN":
+                            state_max_attempts = 20
+                        else:
+                            # Other states - use minimal retries
+                            state_max_attempts = 5
+                        
+                        if attempt < state_max_attempts - 1:  # Not the last attempt for this state
+                            # Calculate exponential backoff with jitter
+                            delay = min(base_delay * (2 ** attempt), max_delay)
+                            jitter = random.uniform(0.1, 0.3) * delay  # 10-30% jitter
+                            total_delay = delay + jitter
+                            
+                            activity.logger.info(
+                                f"Cluster health is {health_result.health_status} (attempt {attempt + 1}/{state_max_attempts}). "
+                                f"Retrying in {total_delay:.1f} seconds..."
+                            )
+                            await asyncio.sleep(total_delay)
+                            attempt += 1
+                            continue
+                        else:
+                            # Last attempt failed for this health state
+                            error_msg = f"Cannot restart pod {input_data.pod_name}: cluster health is {health_result.health_status} after {state_max_attempts} attempts, must be GREEN"
+                            activity.logger.error(error_msg)
+                            raise Exception(error_msg)
+                            
+                except Exception as e:
+                    if "cluster health is" in str(e) and "must be GREEN" in str(e):
+                        # This is our health validation error, re-raise immediately
+                        raise e
+                    
+                    # This is a health check API error - use max attempts for API errors
+                    api_max_attempts = 20
+                    if attempt < api_max_attempts - 1:  # Not the last attempt
+                        # Calculate exponential backoff with jitter
+                        delay = min(base_delay * (2 ** attempt), max_delay)
+                        jitter = random.uniform(0.1, 0.3) * delay  # 10-30% jitter
+                        total_delay = delay + jitter
+                        
+                        activity.logger.warning(
+                            f"Health check failed (attempt {attempt + 1}/{api_max_attempts}): {e}. "
+                            f"Retrying in {total_delay:.1f} seconds..."
+                        )
+                        await asyncio.sleep(total_delay)
+                        attempt += 1
+                        continue
+                    else:
+                        # Last attempt failed
+                        error_msg = f"Health check failed before restarting pod {input_data.pod_name} after {api_max_attempts} attempts: {e}"
+                        activity.logger.error(error_msg)
+                        raise Exception(error_msg)
+
+            # Execute decommission strategy - let Temporal handle failures and retries
+            await self._execute_decommission_strategy(
+                input_data.pod_name,
+                input_data.namespace,
+                input_data.cluster
             )
 
-            # Wait for pod to be ready
+            # Delete the pod - behavior depends on cluster configuration:
+            # - For Kubernetes-managed: deletion triggers preStop hook which handles decommission
+            # - For manual: decommission already completed, just delete the pod
+            grace_period = 30
+            if input_data.cluster.has_dc_util:
+                # Longer grace period for preStop hook to complete decommission
+                grace_period = input_data.cluster.dc_util_timeout + 60
+                activity.logger.info(f"Deleting pod {input_data.pod_name} - preStop hook will handle decommission")
+            else:
+                activity.logger.info(f"Manual decommission completed, now deleting pod {input_data.pod_name}")
+
+            await asyncio.to_thread(
+                self.core_v1.delete_namespaced_pod,
+                name=input_data.pod_name,
+                namespace=input_data.namespace,
+                grace_period_seconds=grace_period
+            )
+
+            # Wait for pod to be ready (after recreation)
             await self._wait_for_pod_ready(
                 input_data.pod_name,
                 input_data.namespace,
@@ -395,6 +548,200 @@ class CrateDBActivities:
                 started_at=started_at,
                 completed_at=None,
             )
+
+    @activity.defn
+    async def decommission_pod(self, input_data: DecommissionInput) -> DecommissionResult:
+        """
+        Decommission a CrateDB pod using the appropriate strategy.
+
+        This activity detects whether the cluster has Kubernetes-managed decommission
+        (preStop hook with dc_util) or requires manual decommission, then executes
+        the appropriate strategy.
+        """
+        start_time = datetime.now(timezone.utc)
+        activity.logger.info(f"Starting decommission for pod {input_data.pod_name}")
+
+        if input_data.dry_run:
+            activity.logger.info(f"[DRY RUN] Would decommission pod {input_data.pod_name}")
+            return DecommissionResult(
+                pod_name=input_data.pod_name,
+                namespace=input_data.namespace,
+                strategy_used="dry_run",
+                success=True,
+                duration=0.0,
+                started_at=start_time,
+                completed_at=datetime.now(timezone.utc)
+            )
+
+        try:
+            # Execute decommission strategy - let Temporal handle failures
+            await self._execute_decommission_strategy(
+                input_data.pod_name,
+                input_data.namespace,
+                input_data.cluster
+            )
+
+            end_time = datetime.now(timezone.utc)
+            duration = (end_time - start_time).total_seconds()
+
+            strategy_used = "kubernetes_managed" if input_data.cluster.has_dc_util else "manual"
+
+            activity.logger.info(f"Decommission completed for pod {input_data.pod_name} using {strategy_used} strategy")
+
+            return DecommissionResult(
+                pod_name=input_data.pod_name,
+                namespace=input_data.namespace,
+                strategy_used=strategy_used,
+                success=True,
+                duration=duration,
+                started_at=start_time,
+                completed_at=end_time,
+                decommission_timeout=input_data.cluster.dc_util_timeout
+            )
+
+        except Exception as e:
+            end_time = datetime.now(timezone.utc)
+            duration = (end_time - start_time).total_seconds()
+            error_msg = f"Decommission failed for pod {input_data.pod_name}: {str(e)}"
+            activity.logger.error(error_msg)
+
+            return DecommissionResult(
+                pod_name=input_data.pod_name,
+                namespace=input_data.namespace,
+                strategy_used="unknown",
+                success=False,
+                duration=duration,
+                error=error_msg,
+                started_at=start_time,
+                completed_at=end_time
+            )
+
+    async def _execute_decommission_strategy(self, pod_name: str, namespace: str, cluster: CrateDBCluster) -> None:
+        """Execute the appropriate decommission strategy based on cluster configuration."""
+        activity.logger.info(f"Analyzing decommission strategy for pod {pod_name}")
+        activity.logger.info(f"Cluster config: has_prestop_hook={cluster.has_prestop_hook}, has_dc_util={cluster.has_dc_util}")
+
+        if cluster.has_dc_util:
+            # For Kubernetes-managed decommission, just delete the pod
+            # The preStop hook will handle decommission automatically
+            activity.logger.info(f"Using Kubernetes-managed decommission for pod {pod_name}")
+            activity.logger.info(f"PreStop hook with dc_util will handle decommission automatically")
+            # Nothing to do here - pod deletion in restart_pod will trigger preStop hook
+        else:
+            await self._execute_manual_decommission(pod_name, namespace, cluster)
+
+
+
+    async def _execute_manual_decommission(self, pod_name: str, namespace: str, cluster: CrateDBCluster) -> None:
+        """
+        Execute manual decommission when no dc_util is configured.
+
+        This executes the decommission commands and waits for the CrateDB process to exit.
+        The caller is responsible for deleting the pod after this completes.
+        """
+        activity.logger.info(f"Using manual decommission for pod {pod_name}")
+        activity.logger.info(f"No dc_util configured - executing manual decommission via CrateDB API")
+
+        # Execute manual decommission commands
+        pod_suffix = pod_name.rsplit("-", 1)[-1]
+
+        # Configuration for manual decommission
+        timeout_value = f"{cluster.dc_util_timeout}s"
+        force_value = True
+        min_availability = cluster.min_availability
+
+        # SQL commands to execute
+        sql_commands = [
+            'set global transient "cluster.routing.allocation.enable" = "new_primaries"',
+            f'set global transient "cluster.graceful_stop.timeout" = "{timeout_value}"',
+            f'set global transient "cluster.graceful_stop.force" = {str(force_value).lower()}',
+            f'set global transient "cluster.graceful_stop.min_availability" = "{min_availability}"',
+            f"alter cluster decommission $$data-hot-{pod_suffix}$$"
+        ]
+
+        # Execute each command
+        for idx, sql_cmd in enumerate(sql_commands, 1):
+            activity.logger.debug(f"Executing manual decommission SQL {idx}/5: {sql_cmd}")
+
+            # Create curl command
+            json_payload = json.dumps({"stmt": sql_cmd})
+            curl_cmd = f'curl --insecure -sS -H "Content-Type: application/json" -X POST https://127.0.0.1:4200/_sql -d \'{json_payload}\''
+
+            if idx == 5:  # Final decommission command
+                # For the decommission command, wait for process to exit
+                curl_cmd = f"""
+                curl_output=$(curl --insecure -sS -H "Content-Type: application/json" -X POST https://127.0.0.1:4200/_sql -d '{json_payload}')
+                curl_exit_code=$?
+                echo "DECOMMISSION_EXIT_CODE: $curl_exit_code"
+                echo "DECOMMISSION_RESPONSE: $curl_output"
+                if [ $curl_exit_code -eq 0 ]; then
+                    echo "Waiting for CrateDB process to exit after decommission..."
+                    while kill -0 1 2>/dev/null; do
+                        echo "Waiting for crate to exit..."
+                        sleep 0.5
+                    done
+                    echo "CrateDB process has exited - decommission complete"
+                else
+                    echo "Decommission command failed with exit code $curl_exit_code"
+                    exit $curl_exit_code
+                fi
+                """
+
+            # Execute command in pod - Temporal handles timeouts and retries
+            resp = await self._execute_command_in_pod(pod_name, namespace, curl_cmd)
+
+            if idx == 5:
+                activity.logger.info(f"Manual decommission completed - CrateDB process has exited")
+                activity.logger.info(f"Pod {pod_name} is ready for deletion and restart")
+                activity.logger.debug(f"Decommission response: {resp}")
+            else:
+                activity.logger.debug(f"Manual decommission command {idx} completed")
+
+        activity.logger.info(f"Manual decommission strategy completed for pod {pod_name}")
+
+    async def _execute_command_in_pod(self, pod_name: str, namespace: str, command: str) -> str:
+        """Execute a command in a pod using kubectl exec. Temporal handles timeouts and retries."""
+        activity.logger.debug(f"Executing command in pod {pod_name}: {command[:100]}...")
+
+        exec_command = ["/bin/sh", "-c", command]
+        resp = await asyncio.to_thread(
+            stream.stream,
+            self.core_v1.connect_get_namespaced_pod_exec,
+            pod_name,
+            namespace,
+            container="crate",
+            command=exec_command,
+            stderr=True,
+            stdin=False,
+            stdout=True,
+            tty=False,
+        )
+
+        activity.logger.debug(f"Command output: {resp}")
+        return resp
+
+    async def _wait_for_pod_deletion(self, pod_name: str, namespace: str, timeout: int) -> None:
+        """Wait for pod to be deleted."""
+        start_time = time.time()
+
+        while time.time() - start_time < timeout:
+            try:
+                await asyncio.to_thread(
+                    self.core_v1.read_namespaced_pod,
+                    name=pod_name,
+                    namespace=namespace
+                )
+                activity.logger.debug(f"Pod {pod_name} still exists, waiting for deletion...")
+                await asyncio.sleep(5)
+            except ApiException as e:
+                if e.status == 404:
+                    activity.logger.info(f"Pod {pod_name} has been deleted")
+                    return
+                else:
+                    activity.logger.warning(f"Error checking pod deletion status: {e}")
+                    await asyncio.sleep(5)
+
+        raise TimeoutError(f"Pod {pod_name} was not deleted within {timeout}s")
 
     async def _wait_for_pod_ready(self, pod_name: str, namespace: str, timeout: int) -> None:
         """Wait for a pod to be ready."""
@@ -460,6 +807,8 @@ class CrateDBActivities:
                 )
 
             # Get fresh cluster CRD information
+            activity.logger.debug(f"Checking health for cluster {cluster.name} (CRD: {cluster.crd_name}) in namespace {cluster.namespace}")
+
             crd = self.custom_api.get_namespaced_custom_object(
                 group="cloud.crate.io",
                 version="v1",
@@ -468,10 +817,11 @@ class CrateDBActivities:
                 name=cluster.crd_name,
             )
 
+            activity.logger.debug(f"Retrieved CRD status: {crd.get('status', {})}")
             health = self._extract_health_status(crd)
-            
+
             activity.logger.info(f"Cluster {cluster.name} health: {health}")
-            
+
             # Handle different health statuses
             if health == "GREEN":
                 return HealthCheckResult(
@@ -480,11 +830,13 @@ class CrateDBActivities:
                     is_healthy=True,
                     checked_at=checked_at,
                 )
-            elif health in ["UNREACHABLE", "YELLOW", "RED"]:
+            elif health in ["YELLOW", "RED", "UNREACHABLE", "UNKNOWN"]:
                 # These are temporary states that should trigger retries
+                activity.logger.info(f"Cluster {cluster.name} health is {health}, retrying until GREEN...")
                 raise Exception(f"Cluster {cluster.name} health is {health}, retrying...")
             else:
-                # UNKNOWN or other statuses are permanent failures
+                # Unknown health states - return as unhealthy but don't retry
+                activity.logger.error(f"Cluster {cluster.name} has unknown health status: {health}")
                 return HealthCheckResult(
                     cluster_name=cluster.name,
                     health_status=health,
@@ -495,6 +847,7 @@ class CrateDBActivities:
         except Exception as e:
             error_msg = f"Error checking cluster health: {e}"
             activity.logger.error(error_msg)
+            activity.logger.debug(f"Health check exception details for {cluster.name}: {type(e).__name__}: {str(e)}")
 
             return HealthCheckResult(
                 cluster_name=cluster.name,
@@ -508,21 +861,21 @@ class CrateDBActivities:
     async def check_maintenance_window(self, input_data: MaintenanceWindowCheckInput) -> MaintenanceWindowCheckResult:
         """
         Check if cluster restart should proceed based on maintenance windows.
-        
+
         Args:
             input_data: Maintenance window check input
-            
+
         Returns:
             MaintenanceWindowCheckResult with decision and reasoning
         """
         current_time = input_data.current_time or datetime.now(timezone.utc)
-        
+
         # Ensure current_time is timezone-aware (defensive programming for Temporal serialization)
         if current_time.tzinfo is None:
             current_time = current_time.replace(tzinfo=timezone.utc)
-        
+
         activity.logger.info(f"Checking maintenance window for cluster {input_data.cluster_name} at {current_time}")
-        
+
         try:
             if not input_data.config_path:
                 # No maintenance config provided - proceed without restrictions
@@ -533,28 +886,28 @@ class CrateDBActivities:
                     current_time=current_time,
                     in_maintenance_window=False
                 )
-            
+
             # Initialize maintenance window checker
             checker = MaintenanceWindowChecker(input_data.config_path)
-            
+
             # Check if currently in maintenance window
             in_window, window_reason = checker.is_in_maintenance_window(
-                input_data.cluster_name, 
+                input_data.cluster_name,
                 current_time
             )
-            
+
             # Make decision about whether to wait
             should_wait, decision_reason = checker.should_wait_for_maintenance_window(
                 input_data.cluster_name,
                 current_time
             )
-            
+
             # Get next window start time for additional context
             next_window_start, _ = checker.get_next_maintenance_window(
                 input_data.cluster_name,
                 current_time
             )
-            
+
             # Log with appropriate level based on decision
             if should_wait and not in_window:
                 activity.logger.warning(f"Cluster {input_data.cluster_name} is OUTSIDE maintenance window - "
@@ -565,7 +918,7 @@ class CrateDBActivities:
             else:
                 activity.logger.info(f"Maintenance window check for {input_data.cluster_name}: "
                                    f"should_wait={should_wait}, in_window={in_window}, reason={decision_reason}")
-            
+
             return MaintenanceWindowCheckResult(
                 cluster_name=input_data.cluster_name,
                 should_wait=should_wait,
@@ -574,11 +927,11 @@ class CrateDBActivities:
                 current_time=current_time,
                 in_maintenance_window=in_window
             )
-            
+
         except FileNotFoundError as e:
             error_msg = f"Maintenance configuration file not found: {e}"
             activity.logger.warning(error_msg)
-            
+
             return MaintenanceWindowCheckResult(
                 cluster_name=input_data.cluster_name,
                 should_wait=False,
@@ -586,11 +939,11 @@ class CrateDBActivities:
                 current_time=current_time,
                 in_maintenance_window=False
             )
-            
+
         except Exception as e:
             error_msg = f"Error checking maintenance window: {e}"
             activity.logger.error(error_msg)
-            
+
             # On error, proceed with restart to avoid blocking operations
             return MaintenanceWindowCheckResult(
                 cluster_name=input_data.cluster_name,

--- a/rr/maintenance_windows.py
+++ b/rr/maintenance_windows.py
@@ -73,6 +73,8 @@ class ClusterMaintenanceConfig(BaseModel):
     windows: List[MaintenanceWindow] = Field(default_factory=list)
     timezone: str = "UTC"
     min_window_duration: int = 30  # Minimum minutes needed for maintenance
+    dc_util_timeout: int = 720  # Default timeout for dc_util in seconds
+    min_availability: str = "PRIMARIES"  # PRIMARIES, NONE, or FULL
 
 
 class MaintenanceWindowChecker:
@@ -135,7 +137,9 @@ class MaintenanceWindowChecker:
                 cluster_name=cluster_name,
                 windows=windows,
                 timezone=cluster_data.get('timezone', 'UTC'),
-                min_window_duration=cluster_data.get('min_window_duration', 30)
+                min_window_duration=cluster_data.get('min_window_duration', 30),
+                dc_util_timeout=cluster_data.get('dc_util_timeout', 720),
+                min_availability=cluster_data.get('min_availability', 'PRIMARIES')
             )
             
             self._configs[cluster_name] = config

--- a/rr/models.py
+++ b/rr/models.py
@@ -22,6 +22,7 @@ class CrateDBCluster(BaseModel):
     suspended: bool = False
     crd_name: str  # The CRD resource name (metadata.name)
     dc_util_timeout: int = 720  # Default timeout for dc_util in seconds
+    min_availability: str = "PRIMARIES"  # PRIMARIES, NONE, or FULL
 
 
 class RestartOptions(BaseModel):
@@ -70,6 +71,7 @@ class ClusterDiscoveryInput(BaseModel):
     cluster_names: Optional[List[str]] = None
     kubeconfig: Optional[str] = None
     context: Optional[str] = None
+    maintenance_config_path: Optional[str] = None
 
 
 class ClusterDiscoveryResult(BaseModel):
@@ -160,3 +162,27 @@ class MaintenanceWindowCheckResult(BaseModel):
     next_window_start: Optional[datetime] = None
     current_time: datetime
     in_maintenance_window: bool = False
+
+
+class DecommissionInput(BaseModel):
+    """Input for decommission activity."""
+    
+    pod_name: str
+    namespace: str
+    cluster: CrateDBCluster
+    dry_run: bool = False
+
+
+class DecommissionResult(BaseModel):
+    """Result of decommission activity."""
+    
+    pod_name: str
+    namespace: str
+    strategy_used: str  # "kubernetes_managed" or "manual"
+    success: bool
+    duration: float
+    error: Optional[str] = None
+    started_at: Optional[datetime] = None
+    completed_at: Optional[datetime] = None
+    process_exited: bool = False  # For manual decommission
+    decommission_timeout: int = 720

--- a/snippet-decommssion.py
+++ b/snippet-decommssion.py
@@ -1,0 +1,178 @@
+    def execute_decommission(self, pod_name: str, namespace: str, metrics: PodOperationMetrics) -> bool:
+        """Execute decommission commands for a CrateDB pod."""
+        pod_suffix = pod_name.rsplit("-", 1)[-1]
+
+        timeout_value = "720s"
+        force_value = True
+        min_availability = "PRIMARIES"
+        loop_message = "wait for crate to exit..."
+
+        metrics.decommission_start = datetime.datetime.now()  # Use the passed metrics object
+
+        # Load namespace-specific configuration
+        namespace_config = MaintenancePlan.load_namespace_config()
+
+        # Apply namespace-specific configuration if available
+        if namespace in namespace_config:
+            metrics.min_availability = namespace_config[namespace]["min_availability"]
+            metrics.timeout_value = namespace_config[namespace]["timeout_value"]
+            config = namespace_config[namespace]
+            min_availability = config["min_availability"]
+            timeout_value = config["timeout_value"]
+            maintenance_window = config.get("maintenance_window", {})
+            logger.warning(f"{mode}Using custom settings for namespace {namespace}: min_availability={min_availability}, timeout={timeout_value}")
+
+            in_maintenance = MaintenancePlan.is_in_maintenance_window(maintenance_window)
+
+            if maintenance_window and not in_maintenance:
+                logger.warning(f"{mode}Outside maintenance window {namespace}: Maintenance Window={maintenance_window}")
+
+                retry_count = 6 * 24 * 2  # 2 days
+                for attempt in range(retry_count):
+                    wait_time_sec = 60 * 10  # 10 minutes
+                    logger.warning(f"{mode}Waiting for 10 minutes before retry {attempt + 1}/{retry_count}...")
+                    interactive_pause(
+                        wait_time_sec,
+                        prompt=f"Waiting for maintenance window (attempt {attempt + 1}/{retry_count})...",
+                    )
+
+                    # Re-check the maintenance window after waiting
+                    in_maintenance = CratePodDrainer.is_in_maintenance_window(maintenance_window)
+                    if in_maintenance:
+                        logger.info(f"{mode}Now within maintenance window {namespace}")
+                        break
+                    logger.warning(f"{mode}Still outside maintenance window")
+
+                if not in_maintenance:
+                    logger.error(f"{mode}Outside maintenance window after {retry_count} attempts.")
+                    sys.exit(1)
+            else:
+                if in_maintenance:
+                    logger.info(f"{mode}Within maintenance window {namespace}: Maintenance Window={maintenance_window}")
+
+        # Create JSON payloads for the SQL commands
+        json_payload_new_primaries = json.dumps({"stmt": 'set global transient "cluster.routing.allocation.enable" = "new_primaries"'})
+        json_payload_timeout = json.dumps({"stmt": f'set global transient "cluster.graceful_stop.timeout" = "{timeout_value}"'})
+        json_payload_force = json.dumps({"stmt": f'set global transient "cluster.graceful_stop.force" = {str(force_value).lower()}'})
+        json_payload_min_availability = json.dumps({"stmt": f'set global transient "cluster.graceful_stop.min_availability" = "{min_availability}"'})
+        json_payload_decommission = json.dumps({"stmt": f"alter cluster decommission $$data-hot-{pod_suffix}$$"})
+
+        logger.info(f"{mode}Decommissioning pod with command: {json_payload_decommission}")
+
+        # Define the commands to execute
+        commands = [
+            f"curl --insecure -sS -H \"Content-Type: application/json\" -X POST https://127.0.0.1:4200/_sql -d '{json_payload_new_primaries}'",
+            f"curl --insecure -sS -H \"Content-Type: application/json\" -X POST https://127.0.0.1:4200/_sql -d '{json_payload_timeout}'",
+            f"curl --insecure -sS -H \"Content-Type: application/json\" -X POST https://127.0.0.1:4200/_sql -d '{json_payload_force}'",
+            f"curl --insecure -sS -H \"Content-Type: application/json\" -X POST https://127.0.0.1:4200/_sql -d '{json_payload_min_availability}'",
+            f"""
+            curl_output=$(curl --insecure -sS -H "Content-Type: application/json" -X POST https://127.0.0.1:4200/_sql -d \'{json_payload_decommission}\')
+            curl_exit_code=$?
+            echo "DECOMMISSION_EXIT_CODE: $curl_exit_code"
+            echo "DECOMMISSION_RESPONSE: $curl_output"
+            if [ $curl_exit_code -eq 0 ]; then
+                while kill -0 1 2>/dev/null; do
+                    echo {loop_message}
+                    sleep 0.5
+                done
+            else
+                echo "Decommission command failed with exit code $curl_exit_code"
+            fi
+            """,
+        ]
+
+        if self.options.dry_run:
+            logger.info(f"{mode}[DRY RUN] Would execute decommission commands on pod {pod_name}")
+            return True
+
+        exec_cnt = 0
+        try:
+            for idx, cmd in enumerate(commands):
+                exec_cnt = idx + 1
+                start_time = time.time()
+                logger.debug(f"{mode}Executing command {exec_cnt}: {cmd}")
+
+                # Use a reasonable timeout for each command - longer for the decommission command
+                timeout = (
+                    1200 if exec_cnt == 5 else 60  #
+                )  # 20 minutes for decommission, 1 minute for others //TODO: ????
+                status, resp = self.execute_with_timeout(pod_name, namespace, cmd, timeout)
+
+                elapsed = time.time() - start_time
+
+                if status == "timeout":
+                    logger.warning(f"{mode}Command {exec_cnt} timed out after {elapsed:.2f}s: {resp}")
+                    if exec_cnt == 5:
+                        # For the decommission command, a timeout might still mean success
+                        logger.info(f"{mode}Decommission command timed out, but it may still be proceeding")
+                        return True
+                    else:
+                        # For other commands, a timeout is likely an issue
+                        logger.error(f"{mode}Command {exec_cnt} failed with timeout")
+                        return False
+                elif status == "error":
+                    if exec_cnt < 5:  # decommission statement not fired yet
+                        logger.error(f"{mode}Command {exec_cnt} failed with error: {resp}")
+                        return False
+                    else:
+                        # For decommission command, some errors might be due to connection loss during successful decommission
+                        logger.warning(f"{mode}Decommission command failed with error: {resp}")
+                        logger.warning(f"{mode}This might be due to the pod restarting during decommission, which could be normal")
+                        return True
+                else:
+                    # Process the response based on which command was executed
+                    if exec_cnt == 5:  # This is the decommission command
+                        exit_code = None
+                        decom_response = None
+                        waiting_count = 0
+                        other_messages = []
+
+                        # Parse the output to extract structured information
+                        for line in resp.splitlines():
+                            if "DECOMMISSION_EXIT_CODE:" in line:
+                                try:
+                                    exit_code = int(line.split(":", 1)[1].strip())
+                                except (ValueError, IndexError):
+                                    exit_code = -1
+                            elif "DECOMMISSION_RESPONSE:" in line:
+                                decom_response = line.split(":", 1)[1].strip() if ":" in line else line
+                            elif loop_message in line:
+                                waiting_count += 1
+                            elif line.strip():
+                                other_messages.append(line)
+
+                        # Log the decommission status with all captured info
+                        logger.info(f"{mode}Command ({exec_cnt}) results for pod {pod_name}:")
+                        logger.info(f"{mode} - Exit code: {exit_code if exit_code is not None else 'N/A'}")
+                        logger.info(f"{mode} - Response: {decom_response or 'Empty response'}")
+                        logger.info(f"{mode} - Wait messages: {waiting_count}x '{loop_message}'")
+
+                        if other_messages:
+                            logger.info(f"{mode} - Other output: {' | '.join(other_messages)}")
+
+                        logger.info(f"{mode}Command executed in {elapsed:.2f} seconds")
+                        metrics.decommission_total_time = f"{elapsed:.2f}"
+                        metrics.waiting_count = waiting_count
+
+                        # If we have an exit code, check it
+                        if exit_code is not None and exit_code != 0:
+                            logger.warning(f"{mode}Decommission command returned non-zero exit code: {exit_code}")
+                            # Still return True because the command executed, even if it failed
+                            # The pod may still be decommissioned successfully
+                    else:
+                        # For other commands, log the full response
+                        logger.info(f"{mode}Command ({exec_cnt}) output {pod_name}: {resp} (Executed in {elapsed:.2f} seconds)")
+
+            # If all commands executed successfully
+            metrics.decommission_end = datetime.datetime.now()
+            logger.opt(colors=True).info(f"{mode}<green>Decommission command {exec_cnt} completed for {pod_name}</green>")
+            return True
+
+        except Exception as e:
+            elapsed = time.time() - start_time
+            if exec_cnt < 5:  # decommission statement not fired yet
+                logger.error(f"{mode}Exec failed on {exec_cnt} before decommission run for pod {pod_name} in {elapsed:.2f} seconds: {e}")
+                return False
+            else:
+                logger.warning(f"{mode}Exception during decommission for pod {pod_name}, but command may still succeed: {e}")
+                return True

--- a/test_health_retry_logic.py
+++ b/test_health_retry_logic.py
@@ -1,0 +1,510 @@
+#!/usr/bin/env python3
+"""
+Test script to verify the exponential backoff retry logic for health checks.
+
+This test ensures that health checks retry properly with exponential backoff
+and handle different cluster states correctly.
+"""
+
+import asyncio
+import logging
+import time
+from unittest.mock import AsyncMock, patch
+
+from rr.activities import CrateDBActivities
+from rr.models import (
+    CrateDBCluster,
+    HealthCheckInput,
+    HealthCheckResult,
+    PodRestartInput,
+)
+
+# Setup logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+async def test_exponential_backoff_timing():
+    """Test that exponential backoff timing works correctly."""
+    
+    logger.info("🧪 Testing exponential backoff timing...")
+    
+    # Create test cluster
+    cluster = CrateDBCluster(
+        name="test-cluster",
+        namespace="test-namespace",
+        crd_name="test-crd",
+        statefulset_name="test-sts",
+        replicas=2,
+        pods=["test-pod-0", "test-pod-1"],
+        health="YELLOW",
+        has_dc_util=True,
+        dc_util_timeout=300,
+        has_prestop_hook=True,
+    )
+    
+    restart_input = PodRestartInput(
+        pod_name="test-pod-0",
+        namespace="test-namespace",
+        cluster=cluster,
+        dry_run=False,
+        pod_ready_timeout=300,
+    )
+    
+    activities = CrateDBActivities()
+    
+    # Mock health check to return YELLOW for first few attempts, then GREEN
+    call_count = 0
+    expected_delays = []
+    actual_delays = []
+    start_time = None
+    
+    async def mock_health_check(input_data):
+        nonlocal call_count, start_time
+        call_count += 1
+        
+        current_time = time.time()
+        if start_time is not None:
+            actual_delays.append(current_time - start_time)
+        start_time = current_time
+        
+        if call_count <= 3:
+            # First 3 attempts return YELLOW
+            return HealthCheckResult(
+                cluster_name="test-cluster",
+                health_status="YELLOW",
+                is_healthy=False,
+                checked_at=None,
+            )
+        else:
+            # 4th attempt returns GREEN
+            return HealthCheckResult(
+                cluster_name="test-cluster",
+                health_status="GREEN",
+                is_healthy=True,
+                checked_at=None,
+            )
+    
+    # Calculate expected delays (base_delay * (2 ** attempt) with some tolerance for jitter)
+    base_delay = 2.0
+    for attempt in range(3):  # 3 retries before success
+        expected_delay = base_delay * (2 ** attempt)
+        expected_delays.append(expected_delay)
+    
+    with patch.object(activities, 'check_cluster_health', side_effect=mock_health_check):
+        with patch.object(activities, '_ensure_kube_client'):
+            with patch.object(activities, '_execute_decommission_strategy'):
+                with patch('asyncio.to_thread'):
+                    with patch.object(activities, '_wait_for_pod_ready'):
+                        
+                        start_total = time.time()
+                        result = await activities.restart_pod(restart_input)
+                        total_time = time.time() - start_total
+                        
+                        # Verify success
+                        assert result.success, f"Expected success but got: {result.error}"
+                        
+                        # Verify call count
+                        assert call_count == 4, f"Expected 4 health checks, got {call_count}"
+                        
+                        # Verify timing (allow for jitter and execution overhead)
+                        assert len(actual_delays) == 3, f"Expected 3 delays, got {len(actual_delays)}"
+                        
+                        for i, (expected, actual) in enumerate(zip(expected_delays, actual_delays[1:])):
+                            # Allow 50% tolerance for jitter and execution time
+                            min_expected = expected * 0.8
+                            max_expected = expected * 1.5
+                            
+                            logger.info(f"Delay {i+1}: expected ~{expected:.1f}s, actual {actual:.1f}s")
+                            assert min_expected <= actual <= max_expected, \
+                                f"Delay {i+1}: expected {expected:.1f}s ±50%, got {actual:.1f}s"
+                        
+                        # Total time should be reasonable
+                        expected_total = sum(expected_delays)
+                        assert total_time >= expected_total * 0.8, \
+                            f"Total time {total_time:.1f}s too short for expected delays {expected_total:.1f}s"
+                        
+                        logger.info(f"✅ Exponential backoff timing verified: {total_time:.1f}s total")
+
+
+async def test_yellow_to_green_transition():
+    """Test YELLOW state retries until GREEN."""
+    
+    logger.info("🧪 Testing YELLOW to GREEN transition...")
+    
+    cluster = CrateDBCluster(
+        name="test-cluster",
+        namespace="test-namespace",
+        crd_name="test-crd",
+        statefulset_name="test-sts",
+        replicas=2,
+        pods=["test-pod-0"],
+        health="YELLOW",
+        has_dc_util=True,
+        dc_util_timeout=300,
+        has_prestop_hook=True,
+    )
+    
+    restart_input = PodRestartInput(
+        pod_name="test-pod-0",
+        namespace="test-namespace",
+        cluster=cluster,
+        dry_run=False,
+        pod_ready_timeout=300,
+    )
+    
+    activities = CrateDBActivities()
+    call_count = 0
+    
+    async def mock_health_check(input_data):
+        nonlocal call_count
+        call_count += 1
+        
+        if call_count <= 2:
+            return HealthCheckResult(
+                cluster_name="test-cluster",
+                health_status="YELLOW",
+                is_healthy=False,
+                checked_at=None,
+            )
+        else:
+            return HealthCheckResult(
+                cluster_name="test-cluster",
+                health_status="GREEN",
+                is_healthy=True,
+                checked_at=None,
+            )
+    
+    with patch.object(activities, 'check_cluster_health', side_effect=mock_health_check):
+        with patch.object(activities, '_ensure_kube_client'):
+            with patch.object(activities, '_execute_decommission_strategy'):
+                with patch('asyncio.to_thread'):
+                    with patch.object(activities, '_wait_for_pod_ready'):
+                        
+                        result = await activities.restart_pod(restart_input)
+                        
+                        assert result.success, f"Expected success but got: {result.error}"
+                        assert call_count == 3, f"Expected 3 health checks, got {call_count}"
+                        
+                        logger.info("✅ YELLOW to GREEN transition handled correctly")
+
+
+async def test_red_state_retry_behavior():
+    """Test RED state retries up to 30 times before failing."""
+    
+    logger.info("🧪 Testing RED state retry behavior...")
+    
+    cluster = CrateDBCluster(
+        name="test-cluster",
+        namespace="test-namespace",
+        crd_name="test-crd",
+        statefulset_name="test-sts",
+        replicas=2,
+        pods=["test-pod-0"],
+        health="RED",
+        has_dc_util=True,
+        dc_util_timeout=300,
+        has_prestop_hook=True,
+    )
+    
+    restart_input = PodRestartInput(
+        pod_name="test-pod-0",
+        namespace="test-namespace",
+        cluster=cluster,
+        dry_run=False,
+        pod_ready_timeout=300,
+    )
+    
+    activities = CrateDBActivities()
+    call_count = 0
+    
+    async def mock_health_check(input_data):
+        nonlocal call_count
+        call_count += 1
+        return HealthCheckResult(
+            cluster_name="test-cluster",
+            health_status="RED",
+            is_healthy=False,
+            checked_at=None,
+        )
+    
+    with patch.object(activities, 'check_cluster_health', side_effect=mock_health_check):
+        with patch.object(activities, '_ensure_kube_client'):
+            
+            result = await activities.restart_pod(restart_input)
+            
+            assert not result.success, "Expected failure for RED cluster"
+            assert "cluster health is RED" in result.error, f"Expected RED error, got: {result.error}"
+            assert "after 30 attempts" in result.error, f"Expected 30 attempts error, got: {result.error}"
+            assert call_count == 30, f"Expected 30 health checks for RED state, got {call_count}"
+            
+            logger.info("✅ RED state retry behavior verified")
+
+
+async def test_unknown_state_retry_behavior():
+    """Test UNKNOWN state retries up to 20 times before failing."""
+    
+    logger.info("🧪 Testing UNKNOWN state retry behavior...")
+    
+    cluster = CrateDBCluster(
+        name="test-cluster",
+        namespace="test-namespace",
+        crd_name="test-crd",
+        statefulset_name="test-sts",
+        replicas=2,
+        pods=["test-pod-0"],
+        health="UNKNOWN",
+        has_dc_util=True,
+        dc_util_timeout=300,
+        has_prestop_hook=True,
+    )
+    
+    restart_input = PodRestartInput(
+        pod_name="test-pod-0",
+        namespace="test-namespace",
+        cluster=cluster,
+        dry_run=False,
+        pod_ready_timeout=300,
+    )
+    
+    activities = CrateDBActivities()
+    call_count = 0
+    
+    async def mock_health_check(input_data):
+        nonlocal call_count
+        call_count += 1
+        # Always return UNKNOWN to test max retries for this state
+        return HealthCheckResult(
+            cluster_name="test-cluster",
+            health_status="UNKNOWN",
+            is_healthy=False,
+            checked_at=None,
+        )
+    
+    with patch.object(activities, 'check_cluster_health', side_effect=mock_health_check):
+        with patch.object(activities, '_ensure_kube_client'):
+            
+            result = await activities.restart_pod(restart_input)
+            
+            assert not result.success, "Expected failure for UNKNOWN cluster after max retries"
+            assert "cluster health is UNKNOWN" in result.error, f"Expected UNKNOWN error, got: {result.error}"
+            assert "after 20 attempts" in result.error, f"Expected 20 attempts error, got: {result.error}"
+            assert call_count == 20, f"Expected 20 health checks for UNKNOWN state, got {call_count}"
+            
+            logger.info("✅ UNKNOWN state retry behavior verified")
+
+
+async def test_max_retries_exhausted():
+    """Test that max retries are exhausted for persistent YELLOW state."""
+    
+    logger.info("🧪 Testing max retries exhausted...")
+    
+    cluster = CrateDBCluster(
+        name="test-cluster",
+        namespace="test-namespace",
+        crd_name="test-crd",
+        statefulset_name="test-sts",
+        replicas=2,
+        pods=["test-pod-0"],
+        health="YELLOW",
+        has_dc_util=True,
+        dc_util_timeout=300,
+        has_prestop_hook=True,
+    )
+    
+    restart_input = PodRestartInput(
+        pod_name="test-pod-0",
+        namespace="test-namespace",
+        cluster=cluster,
+        dry_run=False,
+        pod_ready_timeout=300,
+    )
+    
+    activities = CrateDBActivities()
+    call_count = 0
+    
+    async def mock_health_check(input_data):
+        nonlocal call_count
+        call_count += 1
+        # Always return YELLOW to test max retries
+        return HealthCheckResult(
+            cluster_name="test-cluster",
+            health_status="YELLOW",
+            is_healthy=False,
+            checked_at=None,
+        )
+    
+    with patch.object(activities, 'check_cluster_health', side_effect=mock_health_check):
+        with patch.object(activities, '_ensure_kube_client'):
+            
+            start_time = time.time()
+            result = await activities.restart_pod(restart_input)
+            total_time = time.time() - start_time
+            
+            assert not result.success, "Expected failure after max retries"
+            assert "after 30 attempts" in result.error, f"Expected max attempts error, got: {result.error}"
+            assert call_count == 30, f"Expected 30 health checks, got {call_count}"
+            
+            # Should take reasonable time (exponential backoff)
+            assert total_time >= 60, f"Expected at least 60s for 30 retries, got {total_time:.1f}s"
+            assert total_time <= 900, f"Expected less than 900s, got {total_time:.1f}s"
+            
+            logger.info(f"✅ Max retries exhausted correctly in {total_time:.1f}s")
+
+
+async def test_health_check_api_errors():
+    """Test handling of health check API errors with retries."""
+    
+    logger.info("🧪 Testing health check API error handling...")
+    
+    cluster = CrateDBCluster(
+        name="test-cluster",
+        namespace="test-namespace",
+        crd_name="test-crd",
+        statefulset_name="test-sts",
+        replicas=2,
+        pods=["test-pod-0"],
+        health="UNKNOWN",
+        has_dc_util=True,
+        dc_util_timeout=300,
+        has_prestop_hook=True,
+    )
+    
+    restart_input = PodRestartInput(
+        pod_name="test-pod-0",
+        namespace="test-namespace",
+        cluster=cluster,
+        dry_run=False,
+        pod_ready_timeout=300,
+    )
+    
+    activities = CrateDBActivities()
+    call_count = 0
+    
+    async def mock_health_check(input_data):
+        nonlocal call_count
+        call_count += 1
+        
+        if call_count <= 3:
+            # First 3 attempts fail with API error
+            raise Exception("CrateDB API unreachable")
+        else:
+            # 4th attempt succeeds
+            return HealthCheckResult(
+                cluster_name="test-cluster",
+                health_status="GREEN",
+                is_healthy=True,
+                checked_at=None,
+            )
+    
+    with patch.object(activities, 'check_cluster_health', side_effect=mock_health_check):
+        with patch.object(activities, '_ensure_kube_client'):
+            with patch.object(activities, '_execute_decommission_strategy'):
+                with patch('asyncio.to_thread'):
+                    with patch.object(activities, '_wait_for_pod_ready'):
+                        
+                        result = await activities.restart_pod(restart_input)
+                        
+                        assert result.success, f"Expected success after API errors, got: {result.error}"
+                        assert call_count == 4, f"Expected 4 health checks, got {call_count}"
+                        
+                        logger.info("✅ Health check API error handling verified")
+
+
+async def test_persistent_api_errors():
+    """Test failure after persistent API errors."""
+    
+    logger.info("🧪 Testing persistent API error failure...")
+    
+    cluster = CrateDBCluster(
+        name="test-cluster",
+        namespace="test-namespace",
+        crd_name="test-crd",
+        statefulset_name="test-sts",
+        replicas=2,
+        pods=["test-pod-0"],
+        health="UNKNOWN",
+        has_dc_util=True,
+        dc_util_timeout=300,
+        has_prestop_hook=True,
+    )
+    
+    restart_input = PodRestartInput(
+        pod_name="test-pod-0",
+        namespace="test-namespace",
+        cluster=cluster,
+        dry_run=False,
+        pod_ready_timeout=300,
+    )
+    
+    activities = CrateDBActivities()
+    call_count = 0
+    
+    async def mock_health_check(input_data):
+        nonlocal call_count
+        call_count += 1
+        # Always fail with API error
+        raise Exception("CrateDB API unreachable")
+    
+    with patch.object(activities, 'check_cluster_health', side_effect=mock_health_check):
+        with patch.object(activities, '_ensure_kube_client'):
+            
+            result = await activities.restart_pod(restart_input)
+            
+            assert not result.success, "Expected failure after persistent API errors"
+            assert "after 20 attempts" in result.error, f"Expected max attempts error, got: {result.error}"
+            assert "CrateDB API unreachable" in result.error, f"Expected API error, got: {result.error}"
+            assert call_count == 20, f"Expected 20 health checks, got {call_count}"
+            
+            logger.info("✅ Persistent API error failure verified")
+
+
+async def main():
+    """Run all retry logic tests."""
+    logger.info("🧪 Running health check retry logic tests...")
+    logger.info("=" * 60)
+    
+    test_cases = [
+        test_exponential_backoff_timing,
+        test_yellow_to_green_transition,
+        test_red_state_retry_behavior,
+        test_unknown_state_retry_behavior,
+        test_max_retries_exhausted,
+        test_health_check_api_errors,
+        test_persistent_api_errors,
+    ]
+    
+    passed = 0
+    failed = 0
+    
+    for test_case in test_cases:
+        try:
+            logger.info(f"\n🔄 Running {test_case.__name__}...")
+            await test_case()
+            passed += 1
+        except Exception as e:
+            logger.error(f"❌ Test failed: {test_case.__name__}: {e}")
+            failed += 1
+    
+    logger.info(f"\n" + "=" * 60)
+    logger.info(f"📊 Test Results: {passed} passed, {failed} failed")
+    
+    if failed == 0:
+        logger.info("🎉 All retry logic tests passed!")
+        logger.info("✅ Verified features:")
+        logger.info("   - Exponential backoff with jitter (2s base, 30s max)")
+        logger.info("   - YELLOW states retry up to 30 times")
+        logger.info("   - RED states retry up to 30 times")
+        logger.info("   - UNKNOWN states retry up to 20 times")
+        logger.info("   - API errors retry with backoff (20 attempts)")
+        logger.info("   - Max retries properly exhausted")
+        logger.info("   - Proper error messages and logging")
+        return True
+    else:
+        logger.error("💥 Some retry logic tests failed!")
+        return False
+
+
+if __name__ == "__main__":
+    success = asyncio.run(main())
+    exit(0 if success else 1)

--- a/test_health_validation_fix.py
+++ b/test_health_validation_fix.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+"""
+Test script to verify the health validation fix for pod restart regression.
+
+This test ensures that pods are not deleted when the cluster is not GREEN.
+"""
+
+import asyncio
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from rr.activities import CrateDBActivities
+from rr.models import (
+    CrateDBCluster,
+    HealthCheckInput,
+    HealthCheckResult,
+    PodRestartInput,
+    PodRestartResult,
+)
+
+# Setup logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+async def test_pod_restart_blocks_on_non_green_cluster():
+    """Test that pod restart fails when cluster health is not GREEN."""
+    
+    # Create test cluster
+    cluster = CrateDBCluster(
+        name="test-cluster",
+        namespace="test-namespace",
+        crd_name="test-crd",
+        statefulset_name="test-sts",
+        replicas=2,
+        pods=["test-pod-0", "test-pod-1"],
+        health="YELLOW",  # Not GREEN
+        has_dc_util=True,
+        dc_util_timeout=300,
+        has_prestop_hook=True,
+    )
+    
+    # Create pod restart input
+    restart_input = PodRestartInput(
+        pod_name="test-pod-0",
+        namespace="test-namespace",
+        cluster=cluster,
+        dry_run=False,
+        pod_ready_timeout=300,
+    )
+    
+    # Mock the activities
+    activities = CrateDBActivities()
+    
+    # Mock health check to return YELLOW (not GREEN)
+    yellow_health_result = HealthCheckResult(
+        cluster_name="test-cluster",
+        health_status="YELLOW",
+        is_healthy=False,
+        checked_at=None,
+    )
+    
+    with patch.object(activities, 'check_cluster_health', return_value=yellow_health_result) as mock_health_check:
+        with patch.object(activities, '_ensure_kube_client'):
+            # Test should fail because cluster is not GREEN
+            result = await activities.restart_pod(restart_input)
+            
+            # Verify health check was called
+            mock_health_check.assert_called_once()
+            
+            # Verify restart failed due to health check
+            assert not result.success
+            assert "cluster health is YELLOW, must be GREEN" in result.error
+            
+            logger.info("✅ Test passed: Pod restart correctly blocked on YELLOW cluster")
+
+
+async def test_pod_restart_proceeds_on_green_cluster():
+    """Test that pod restart proceeds when cluster health is GREEN."""
+    
+    # Create test cluster
+    cluster = CrateDBCluster(
+        name="test-cluster",
+        namespace="test-namespace",
+        crd_name="test-crd",
+        statefulset_name="test-sts",
+        replicas=2,
+        pods=["test-pod-0", "test-pod-1"],
+        health="GREEN",
+        has_dc_util=True,
+        dc_util_timeout=300,
+        has_prestop_hook=True,
+    )
+    
+    # Create pod restart input
+    restart_input = PodRestartInput(
+        pod_name="test-pod-0",
+        namespace="test-namespace",
+        cluster=cluster,
+        dry_run=False,
+        pod_ready_timeout=300,
+    )
+    
+    # Mock the activities
+    activities = CrateDBActivities()
+    
+    # Mock health check to return GREEN
+    green_health_result = HealthCheckResult(
+        cluster_name="test-cluster",
+        health_status="GREEN",
+        is_healthy=True,
+        checked_at=None,
+    )
+    
+    with patch.object(activities, 'check_cluster_health', return_value=green_health_result) as mock_health_check:
+        with patch.object(activities, '_ensure_kube_client'):
+            with patch.object(activities, '_execute_decommission_strategy', return_value=None) as mock_decommission:
+                with patch('asyncio.to_thread') as mock_to_thread:
+                    with patch.object(activities, '_wait_for_pod_ready', return_value=None) as mock_wait:
+                        
+                        # Test should succeed because cluster is GREEN
+                        result = await activities.restart_pod(restart_input)
+                        
+                        # Verify health check was called
+                        mock_health_check.assert_called_once()
+                        
+                        # Verify decommission strategy was called (after health check passed)
+                        mock_decommission.assert_called_once()
+                        
+                        # Verify pod deletion was attempted
+                        mock_to_thread.assert_called_once()
+                        
+                        # Verify restart succeeded
+                        assert result.success
+                        
+                        logger.info("✅ Test passed: Pod restart correctly proceeded on GREEN cluster")
+
+
+async def test_pod_restart_blocks_on_red_cluster():
+    """Test that pod restart fails when cluster health is RED."""
+    
+    # Create test cluster
+    cluster = CrateDBCluster(
+        name="test-cluster",
+        namespace="test-namespace",
+        crd_name="test-crd",
+        statefulset_name="test-sts",
+        replicas=2,
+        pods=["test-pod-0", "test-pod-1"],
+        health="RED",
+        has_dc_util=True,
+        dc_util_timeout=300,
+        has_prestop_hook=True,
+    )
+    
+    # Create pod restart input
+    restart_input = PodRestartInput(
+        pod_name="test-pod-0",
+        namespace="test-namespace",
+        cluster=cluster,
+        dry_run=False,
+        pod_ready_timeout=300,
+    )
+    
+    # Mock the activities
+    activities = CrateDBActivities()
+    
+    # Mock health check to return RED (unhealthy)
+    red_health_result = HealthCheckResult(
+        cluster_name="test-cluster",
+        health_status="RED",
+        is_healthy=False,
+        checked_at=None,
+    )
+    
+    with patch.object(activities, 'check_cluster_health', return_value=red_health_result) as mock_health_check:
+        with patch.object(activities, '_ensure_kube_client'):
+            # Test should fail because cluster is RED
+            result = await activities.restart_pod(restart_input)
+            
+            # Verify health check was called
+            mock_health_check.assert_called_once()
+            
+            # Verify restart failed due to health check
+            assert not result.success
+            assert "cluster health is RED, must be GREEN" in result.error
+            
+            logger.info("✅ Test passed: Pod restart correctly blocked on RED cluster")
+
+
+async def test_pod_restart_blocks_on_health_check_exception():
+    """Test that pod restart fails when health check throws exception."""
+    
+    # Create test cluster
+    cluster = CrateDBCluster(
+        name="test-cluster",
+        namespace="test-namespace",
+        crd_name="test-crd",
+        statefulset_name="test-sts",
+        replicas=2,
+        pods=["test-pod-0", "test-pod-1"],
+        health="UNKNOWN",
+        has_dc_util=True,
+        dc_util_timeout=300,
+        has_prestop_hook=True,
+    )
+    
+    # Create pod restart input
+    restart_input = PodRestartInput(
+        pod_name="test-pod-0",
+        namespace="test-namespace",
+        cluster=cluster,
+        dry_run=False,
+        pod_ready_timeout=300,
+    )
+    
+    # Mock the activities
+    activities = CrateDBActivities()
+    
+    # Mock health check to throw exception
+    with patch.object(activities, 'check_cluster_health', side_effect=Exception("CrateDB API unreachable")) as mock_health_check:
+        with patch.object(activities, '_ensure_kube_client'):
+            # Test should fail because health check failed
+            result = await activities.restart_pod(restart_input)
+            
+            # Verify health check was called
+            mock_health_check.assert_called_once()
+            
+            # Verify restart failed due to health check exception
+            assert not result.success
+            assert "Health check failed before restarting pod" in result.error
+            assert "CrateDB API unreachable" in result.error
+            
+            logger.info("✅ Test passed: Pod restart correctly blocked on health check exception")
+
+
+async def test_pod_restart_works_for_manual_decommission_clusters():
+    """Test that pod restart with health validation works for non-dc_util clusters."""
+    
+    # Create test cluster without dc_util
+    cluster = CrateDBCluster(
+        name="test-cluster",
+        namespace="test-namespace",
+        crd_name="test-crd",
+        statefulset_name="test-sts",
+        replicas=2,
+        pods=["test-pod-0", "test-pod-1"],
+        health="GREEN",
+        has_dc_util=False,  # No dc_util - manual decommission
+        dc_util_timeout=0,
+        has_prestop_hook=False,
+    )
+    
+    # Create pod restart input
+    restart_input = PodRestartInput(
+        pod_name="test-pod-0",
+        namespace="test-namespace",
+        cluster=cluster,
+        dry_run=False,
+        pod_ready_timeout=300,
+    )
+    
+    # Mock the activities
+    activities = CrateDBActivities()
+    
+    # Mock health check to return GREEN
+    green_health_result = HealthCheckResult(
+        cluster_name="test-cluster",
+        health_status="GREEN",
+        is_healthy=True,
+        checked_at=None,
+    )
+    
+    with patch.object(activities, 'check_cluster_health', return_value=green_health_result) as mock_health_check:
+        with patch.object(activities, '_ensure_kube_client'):
+            with patch.object(activities, '_execute_manual_decommission', return_value=None) as mock_manual_decommission:
+                with patch('asyncio.to_thread') as mock_to_thread:
+                    with patch.object(activities, '_wait_for_pod_ready', return_value=None) as mock_wait:
+                        
+                        # Test should succeed for manual decommission clusters too
+                        result = await activities.restart_pod(restart_input)
+                        
+                        # Verify health check was called first
+                        mock_health_check.assert_called_once()
+                        
+                        # Verify manual decommission was called (after health check passed)
+                        mock_manual_decommission.assert_called_once()
+                        
+                        # Verify pod deletion was attempted
+                        mock_to_thread.assert_called_once()
+                        
+                        # Verify restart succeeded
+                        assert result.success
+                        
+                        logger.info("✅ Test passed: Pod restart with health validation works for manual decommission clusters")
+
+
+async def main():
+    """Run all tests."""
+    logger.info("🧪 Running health validation fix tests...")
+    
+    # Test cases
+    test_cases = [
+        test_pod_restart_blocks_on_non_green_cluster,
+        test_pod_restart_proceeds_on_green_cluster,
+        test_pod_restart_blocks_on_red_cluster,
+        test_pod_restart_blocks_on_health_check_exception,
+        test_pod_restart_works_for_manual_decommission_clusters,
+    ]
+    
+    passed = 0
+    failed = 0
+    
+    for test_case in test_cases:
+        try:
+            logger.info(f"Running {test_case.__name__}...")
+            await test_case()
+            passed += 1
+        except Exception as e:
+            logger.error(f"❌ Test failed: {test_case.__name__}: {e}")
+            failed += 1
+    
+    logger.info(f"\n📊 Test Results: {passed} passed, {failed} failed")
+    
+    if failed == 0:
+        logger.info("🎉 All tests passed! Health validation fix is working correctly.")
+    else:
+        logger.error("💥 Some tests failed! Please review the implementation.")
+        exit(1)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/test_maintenance_config_integration.py
+++ b/test_maintenance_config_integration.py
@@ -1,0 +1,445 @@
+#!/usr/bin/env python3
+"""
+Test script to verify maintenance configuration integration works correctly.
+
+This test ensures that dc_util_timeout and min_availability values from 
+maintenance-windows.toml are properly applied to cluster configurations.
+"""
+
+import asyncio
+import logging
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from rr.activities import CrateDBActivities
+from rr.models import ClusterDiscoveryInput, CrateDBCluster
+from rr.maintenance_windows import MaintenanceWindowChecker
+
+# Setup logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def create_test_maintenance_config():
+    """Create a temporary maintenance configuration file for testing."""
+    config_content = """
+# Test Maintenance Configuration
+[test-cluster-1]
+timezone = "UTC"
+min_window_duration = 30
+dc_util_timeout = 900
+min_availability = "FULL"
+
+[[test-cluster-1.windows]]
+time = "02:00-04:00"
+weekdays = ["sat", "sun"]
+description = "Weekend maintenance"
+
+[test-cluster-2]
+timezone = "UTC"
+min_window_duration = 60
+dc_util_timeout = 1200
+min_availability = "NONE"
+
+[[test-cluster-2.windows]]
+time = "18:00-20:00"
+weekdays = ["mon", "tue", "wed"]
+description = "Evening maintenance"
+
+[test-cluster-default]
+timezone = "UTC"
+min_window_duration = 45
+# No dc_util_timeout or min_availability - should use defaults
+
+[[test-cluster-default.windows]]
+time = "12:00-13:00"
+weekdays = ["fri"]
+description = "Friday lunch maintenance"
+"""
+    
+    temp_file = tempfile.NamedTemporaryFile(mode='w', suffix='.toml', delete=False)
+    temp_file.write(config_content)
+    temp_file.close()
+    return temp_file.name
+
+
+async def test_maintenance_config_loading():
+    """Test that maintenance configuration is loaded correctly."""
+    
+    logger.info("🧪 Testing maintenance configuration loading...")
+    
+    # Create test config file
+    config_path = create_test_maintenance_config()
+    
+    try:
+        # Load maintenance configuration
+        checker = MaintenanceWindowChecker(config_path)
+        
+        # Test cluster with custom values
+        config1 = checker.get_cluster_config("test-cluster-1")
+        assert config1 is not None, "test-cluster-1 config should exist"
+        assert config1.dc_util_timeout == 900, f"Expected dc_util_timeout=900, got {config1.dc_util_timeout}"
+        assert config1.min_availability == "FULL", f"Expected min_availability=FULL, got {config1.min_availability}"
+        
+        # Test cluster with different custom values
+        config2 = checker.get_cluster_config("test-cluster-2")
+        assert config2 is not None, "test-cluster-2 config should exist"
+        assert config2.dc_util_timeout == 1200, f"Expected dc_util_timeout=1200, got {config2.dc_util_timeout}"
+        assert config2.min_availability == "NONE", f"Expected min_availability=NONE, got {config2.min_availability}"
+        
+        # Test cluster with defaults
+        config3 = checker.get_cluster_config("test-cluster-default")
+        assert config3 is not None, "test-cluster-default config should exist"
+        assert config3.dc_util_timeout == 720, f"Expected default dc_util_timeout=720, got {config3.dc_util_timeout}"
+        assert config3.min_availability == "PRIMARIES", f"Expected default min_availability=PRIMARIES, got {config3.min_availability}"
+        
+        # Test non-existent cluster
+        config4 = checker.get_cluster_config("non-existent-cluster")
+        assert config4 is None, "Non-existent cluster should return None"
+        
+        logger.info("✅ Maintenance configuration loading test passed")
+        
+    finally:
+        # Clean up
+        Path(config_path).unlink()
+
+
+async def test_cluster_discovery_with_maintenance_config():
+    """Test that cluster discovery applies maintenance configuration overrides."""
+    
+    logger.info("🧪 Testing cluster discovery with maintenance config...")
+    
+    # Create test config file
+    config_path = create_test_maintenance_config()
+    
+    try:
+        # Create mock CRD item
+        mock_crd_item = {
+            "metadata": {
+                "name": "test-cluster-1",
+                "namespace": "crate-system"
+            },
+            "spec": {
+                "cluster": {
+                    "name": "test-cluster-1"
+                }
+            },
+            "status": {
+                "health": "GREEN"
+            }
+        }
+        
+        # Create mock StatefulSet
+        mock_sts = MagicMock()
+        mock_sts.spec.replicas = 3
+        mock_sts.spec.template.spec.containers = []
+        
+        # Create activities instance
+        activities = CrateDBActivities()
+        
+        # Mock dependencies
+        with patch.object(activities, '_find_statefulset', return_value=("test-sts", mock_sts)):
+            with patch.object(activities, '_analyze_prestop_hook', return_value=(True, True, 720)):
+                with patch.object(activities, '_find_pods', return_value=["test-pod-0", "test-pod-1", "test-pod-2"]):
+                    with patch.object(activities, '_extract_health_status', return_value="GREEN"):
+                        
+                        # Test cluster discovery with maintenance config
+                        cluster = await activities._process_crd_item(
+                            mock_crd_item, 
+                            ["test-cluster-1"], 
+                            config_path
+                        )
+                        
+                        assert cluster is not None, "Cluster should be discovered"
+                        assert cluster.name == "test-cluster-1", f"Expected name=test-cluster-1, got {cluster.name}"
+                        assert cluster.dc_util_timeout == 900, f"Expected dc_util_timeout=900 (from config), got {cluster.dc_util_timeout}"
+                        assert cluster.min_availability == "FULL", f"Expected min_availability=FULL (from config), got {cluster.min_availability}"
+                        
+                        logger.info("✅ Cluster discovery with maintenance config test passed")
+        
+    finally:
+        # Clean up
+        Path(config_path).unlink()
+
+
+async def test_cluster_discovery_without_maintenance_config():
+    """Test that cluster discovery uses defaults when no maintenance config is provided."""
+    
+    logger.info("🧪 Testing cluster discovery without maintenance config...")
+    
+    # Create mock CRD item
+    mock_crd_item = {
+        "metadata": {
+            "name": "test-cluster-no-config",
+            "namespace": "default"
+        },
+        "spec": {
+            "cluster": {
+                "name": "test-cluster-no-config"
+            }
+        },
+        "status": {
+            "health": "YELLOW"
+        }
+    }
+    
+    # Create mock StatefulSet
+    mock_sts = MagicMock()
+    mock_sts.spec.replicas = 2
+    mock_sts.spec.template.spec.containers = []
+    
+    # Create activities instance
+    activities = CrateDBActivities()
+    
+    # Mock dependencies
+    with patch.object(activities, '_find_statefulset', return_value=("test-sts", mock_sts)):
+        with patch.object(activities, '_analyze_prestop_hook', return_value=(False, False, 720)):
+            with patch.object(activities, '_find_pods', return_value=["test-pod-0", "test-pod-1"]):
+                with patch.object(activities, '_extract_health_status', return_value="YELLOW"):
+                    
+                    # Test cluster discovery without maintenance config
+                    cluster = await activities._process_crd_item(
+                        mock_crd_item, 
+                        ["test-cluster-no-config"], 
+                        None  # No maintenance config
+                    )
+                    
+                    assert cluster is not None, "Cluster should be discovered"
+                    assert cluster.name == "test-cluster-no-config", f"Expected name=test-cluster-no-config, got {cluster.name}"
+                    assert cluster.dc_util_timeout == 720, f"Expected default dc_util_timeout=720, got {cluster.dc_util_timeout}"
+                    assert cluster.min_availability == "PRIMARIES", f"Expected default min_availability=PRIMARIES, got {cluster.min_availability}"
+                    
+                    logger.info("✅ Cluster discovery without maintenance config test passed")
+
+
+async def test_manual_decommission_uses_config_values():
+    """Test that manual decommission uses the configuration values from the cluster."""
+    
+    logger.info("🧪 Testing manual decommission uses config values...")
+    
+    # Create test cluster with custom values
+    cluster = CrateDBCluster(
+        name="test-cluster",
+        namespace="test-namespace",
+        crd_name="test-crd",
+        statefulset_name="test-sts",
+        replicas=2,
+        pods=["test-pod-0", "test-pod-1"],
+        health="GREEN",
+        has_dc_util=False,  # Manual decommission
+        dc_util_timeout=1500,  # Custom timeout
+        has_prestop_hook=False,
+        min_availability="NONE"  # Custom min_availability
+    )
+    
+    # Create activities instance
+    activities = CrateDBActivities()
+    
+    # Mock the command execution to capture what SQL is generated
+    executed_commands = []
+    
+    async def mock_execute_command(pod_name, namespace, command):
+        executed_commands.append(command)
+        return "Mock response"
+    
+    with patch.object(activities, '_ensure_kube_client'):
+        with patch.object(activities, '_execute_command_in_pod', side_effect=mock_execute_command):
+            
+            # Execute manual decommission
+            await activities._execute_manual_decommission("test-pod-0", "test-namespace", cluster)
+            
+            # Verify the SQL commands contain our custom values
+            assert len(executed_commands) == 5, f"Expected 5 commands, got {len(executed_commands)}"
+            
+            # Check timeout value is used
+            timeout_command = None
+            min_availability_command = None
+            
+            for cmd in executed_commands:
+                if "cluster.graceful_stop.timeout" in cmd:
+                    timeout_command = cmd
+                if "cluster.graceful_stop.min_availability" in cmd:
+                    min_availability_command = cmd
+            
+            assert timeout_command is not None, "Timeout command should be present"
+            assert "1500s" in timeout_command, f"Expected 1500s in timeout command, got: {timeout_command}"
+            
+            assert min_availability_command is not None, "Min availability command should be present"
+            assert "NONE" in min_availability_command, f"Expected NONE in min_availability command, got: {min_availability_command}"
+            
+            logger.info("✅ Manual decommission uses config values test passed")
+
+
+async def test_cluster_discovery_input_integration():
+    """Test the full integration from ClusterDiscoveryInput to cluster configuration."""
+    
+    logger.info("🧪 Testing full ClusterDiscoveryInput integration...")
+    
+    # Create test config file
+    config_path = create_test_maintenance_config()
+    
+    try:
+        # Create discovery input with maintenance config
+        discovery_input = ClusterDiscoveryInput(
+            cluster_names=["test-cluster-1"],
+            kubeconfig=None,
+            context=None,
+            maintenance_config_path=config_path
+        )
+        
+        # Create mock data
+        mock_crds = {
+            "items": [{
+                "metadata": {
+                    "name": "test-cluster-1",
+                    "namespace": "crate-system"
+                },
+                "spec": {
+                    "cluster": {
+                        "name": "test-cluster-1"
+                    }
+                },
+                "status": {
+                    "health": "GREEN"
+                }
+            }]
+        }
+        
+        mock_sts = MagicMock()
+        mock_sts.spec.replicas = 3
+        mock_sts.spec.template.spec.containers = []
+        
+        # Create activities instance
+        activities = CrateDBActivities()
+        
+        # Mock all dependencies
+        with patch.object(activities, '_ensure_kube_client'):
+            with patch.object(activities.core_v1, 'list_namespace') as mock_list_ns:
+                with patch.object(activities.custom_api, 'list_namespaced_custom_object', return_value=mock_crds):
+                    with patch.object(activities, '_find_statefulset', return_value=("test-sts", mock_sts)):
+                        with patch.object(activities, '_analyze_prestop_hook', return_value=(True, True, 720)):
+                            with patch.object(activities, '_find_pods', return_value=["test-pod-0", "test-pod-1", "test-pod-2"]):
+                                with patch.object(activities, '_extract_health_status', return_value="GREEN"):
+                                    
+                                    # Mock namespace list
+                                    mock_namespace = MagicMock()
+                                    mock_namespace.metadata.name = "crate-system"
+                                    mock_list_ns.return_value.items = [mock_namespace]
+                                    
+                                    # Execute discovery
+                                    result = await activities.discover_clusters(discovery_input)
+                                    
+                                    assert result.total_found == 1, f"Expected 1 cluster found, got {result.total_found}"
+                                    assert len(result.clusters) == 1, f"Expected 1 cluster in result, got {len(result.clusters)}"
+                                    
+                                    cluster = result.clusters[0]
+                                    assert cluster.name == "test-cluster-1", f"Expected name=test-cluster-1, got {cluster.name}"
+                                    assert cluster.dc_util_timeout == 900, f"Expected dc_util_timeout=900 (from config), got {cluster.dc_util_timeout}"
+                                    assert cluster.min_availability == "FULL", f"Expected min_availability=FULL (from config), got {cluster.min_availability}"
+                                    
+                                    logger.info("✅ Full ClusterDiscoveryInput integration test passed")
+        
+    finally:
+        # Clean up
+        Path(config_path).unlink()
+
+
+async def test_invalid_maintenance_config_handling():
+    """Test that invalid maintenance configuration is handled gracefully."""
+    
+    logger.info("🧪 Testing invalid maintenance config handling...")
+    
+    # Create mock CRD item
+    mock_crd_item = {
+        "metadata": {
+            "name": "test-cluster",
+            "namespace": "default"
+        },
+        "spec": {
+            "cluster": {
+                "name": "test-cluster"
+            }
+        },
+        "status": {
+            "health": "GREEN"
+        }
+    }
+    
+    # Create mock StatefulSet
+    mock_sts = MagicMock()
+    mock_sts.spec.replicas = 1
+    mock_sts.spec.template.spec.containers = []
+    
+    # Create activities instance
+    activities = CrateDBActivities()
+    
+    # Mock dependencies
+    with patch.object(activities, '_find_statefulset', return_value=("test-sts", mock_sts)):
+        with patch.object(activities, '_analyze_prestop_hook', return_value=(False, False, 720)):
+            with patch.object(activities, '_find_pods', return_value=["test-pod-0"]):
+                with patch.object(activities, '_extract_health_status', return_value="GREEN"):
+                    
+                    # Test with non-existent config file
+                    cluster = await activities._process_crd_item(
+                        mock_crd_item, 
+                        ["test-cluster"], 
+                        "/non/existent/config.toml"  # Invalid path
+                    )
+                    
+                    # Should still work with defaults
+                    assert cluster is not None, "Cluster should be discovered despite invalid config"
+                    assert cluster.dc_util_timeout == 720, f"Expected fallback to default dc_util_timeout=720, got {cluster.dc_util_timeout}"
+                    assert cluster.min_availability == "PRIMARIES", f"Expected fallback to default min_availability=PRIMARIES, got {cluster.min_availability}"
+                    
+                    logger.info("✅ Invalid maintenance config handling test passed")
+
+
+async def main():
+    """Run all integration tests."""
+    logger.info("🧪 Running maintenance configuration integration tests...")
+    logger.info("=" * 60)
+    
+    test_cases = [
+        test_maintenance_config_loading,
+        test_cluster_discovery_with_maintenance_config,
+        test_cluster_discovery_without_maintenance_config,
+        test_manual_decommission_uses_config_values,
+        test_cluster_discovery_input_integration,
+        test_invalid_maintenance_config_handling,
+    ]
+    
+    passed = 0
+    failed = 0
+    
+    for test_case in test_cases:
+        try:
+            logger.info(f"\n🔄 Running {test_case.__name__}...")
+            await test_case()
+            passed += 1
+        except Exception as e:
+            logger.error(f"❌ Test failed: {test_case.__name__}: {e}")
+            failed += 1
+    
+    logger.info(f"\n" + "=" * 60)
+    logger.info(f"📊 Test Results: {passed} passed, {failed} failed")
+    
+    if failed == 0:
+        logger.info("🎉 All maintenance configuration integration tests passed!")
+        logger.info("\n✅ Verified features:")
+        logger.info("   - Maintenance config loading from TOML files")
+        logger.info("   - dc_util_timeout override from maintenance config")
+        logger.info("   - min_availability override from maintenance config")
+        logger.info("   - Default value fallback when config not available")
+        logger.info("   - Manual decommission uses cluster config values")
+        logger.info("   - Graceful handling of invalid config files")
+        logger.info("   - Full integration through ClusterDiscoveryInput")
+        return True
+    else:
+        logger.error("💥 Some maintenance configuration integration tests failed!")
+        return False
+
+
+if __name__ == "__main__":
+    success = asyncio.run(main())
+    exit(0 if success else 1)

--- a/todo.md
+++ b/todo.md
@@ -3,9 +3,28 @@
 - [x] The code should not work on  SUSPENDED
 - [x] Log a message when a cluster is outside its maintenance window
 - [x] Final health check needs to wait for GREEN, UNREACHABLE needs to wait
+- [x] env values? YELLOW_MAX_ATTEMPTS
 ```
 2025-07-01T11:49:33.998278+0200 | DEBUG | Loaded Kubernetes context: eks1-us-east-1-dev
 Error checking maintenance window: can't compare offset-naive and offset-aware datetimes ({'activity_id': '1', 'activity_type': 'check_maintenance_window', 'attempt': 1, 'namespace': 'default', 'task_queue': 'cratedb-operations', 'workflow_id': 'restart-lime-wicket-systri-warrick-2025-07-01T09:49:40.451048+00:00', 'workflow_run_id': '0197c564-865b-7df6-be19-c65bf74ec396', 'workflow_type': 'ClusterRestartWorkflow'})
 Final health check failed: UNREACHABLE (successfully restarted 1/1 pods) ({'attempt': 1, 'namespace': 'default', 'run_id': '0197c564-865b-7df6-be19-c65bf74ec396', 'task_queue': 'cratedb-operations', 'workflow_id': 'restart-lime-wicket-systri-warrick-2025-07-01T09:49:40.451048+00:00', 'workflow_type': 'ClusterRestartWorkflow'})
 Failed to restart cluster lime-wicket-systri-warrick: Final health check failed: UNREACHABLE (successfully restarted 1/1 pods) ({'attempt': 1, 'namespace': 'default', 'run_id': '0197c564-64de-704a-ab5b-ed0fa2004196', 'task_queue': 'cratedb-operations', 'workflow_id': 'restart-clusters-81a32c5a', 'workflow_type': 'MultiClusterRestartWorkflow'})
+```
+
+```yaml
+imagePullPolicy: IfNotPresent
+lifecycle:
+  preStop:
+    exec:
+      command:
+      - /bin/sh
+      - -c
+      - curl -sLO https://github.com/crate/crate-operator/releases/download/dcutil-0.0.1/dc_util-linux-amd68
+        && curl -sLO https://github.com/crate/crate-operator/releases/download/dcutil-0.0.1/dc_util-linux-amd64.sha256
+        && sha256sum -c dc_util-linux-amd64.sha256 && chmod u+x dc_util-linux-amd64
+        &&./dc_util-linux-amd64 -min-availability PRIMARIES -timeout 720s
+name: crate
+
+
+
 ```

--- a/verify_health_validation_fix.py
+++ b/verify_health_validation_fix.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""
+Simple integration test to verify the health validation fix is in place.
+
+This test verifies that the restart_pod method now includes health validation
+before proceeding with pod deletion.
+"""
+
+import inspect
+import logging
+import sys
+from pathlib import Path
+
+# Add the rr module to the path
+sys.path.insert(0, str(Path(__file__).parent))
+
+from rr.activities import CrateDBActivities
+
+# Setup logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def test_health_validation_exists():
+    """Test that health validation code exists in restart_pod method."""
+    
+    logger.info("🔍 Checking if health validation exists in restart_pod method...")
+    
+    # Get the restart_pod method source code
+    restart_pod_method = getattr(CrateDBActivities, 'restart_pod', None)
+    
+    if not restart_pod_method:
+        logger.error("❌ restart_pod method not found!")
+        return False
+    
+    # Get the source code
+    try:
+        source_code = inspect.getsource(restart_pod_method)
+    except OSError:
+        logger.error("❌ Could not get source code for restart_pod method!")
+        return False
+    
+    # Check for health validation keywords
+    health_validation_checks = [
+        "Validating cluster health before restarting",
+        "check_cluster_health",
+        "cluster health is",
+        "must be GREEN",
+        "Health check failed before restarting",
+    ]
+    
+    found_checks = []
+    missing_checks = []
+    
+    for check in health_validation_checks:
+        if check in source_code:
+            found_checks.append(check)
+            logger.info(f"✅ Found: '{check}'")
+        else:
+            missing_checks.append(check)
+            logger.warning(f"⚠️  Missing: '{check}'")
+    
+    # Check the method structure
+    lines = source_code.split('\n')
+    health_check_found = False
+    decommission_found = False
+    pod_deletion_found = False
+    
+    for i, line in enumerate(lines):
+        if "check_cluster_health" in line:
+            health_check_found = True
+            health_check_line = i
+        elif "_execute_decommission_strategy" in line:
+            decommission_found = True
+            decommission_line = i
+        elif "delete_namespaced_pod" in line:
+            pod_deletion_found = True
+            pod_deletion_line = i
+    
+    # Verify the order: health check should come before decommission and pod deletion
+    if health_check_found and decommission_found and pod_deletion_found:
+        if health_check_line < decommission_line < pod_deletion_line:
+            logger.info("✅ Correct order: health check → decommission → pod deletion")
+            order_correct = True
+        else:
+            logger.error("❌ Incorrect order of operations!")
+            logger.error(f"   Health check line: {health_check_line}")
+            logger.error(f"   Decommission line: {decommission_line}")
+            logger.error(f"   Pod deletion line: {pod_deletion_line}")
+            order_correct = False
+    else:
+        logger.error("❌ Missing critical operations!")
+        logger.error(f"   Health check found: {health_check_found}")
+        logger.error(f"   Decommission found: {decommission_found}")
+        logger.error(f"   Pod deletion found: {pod_deletion_found}")
+        order_correct = False
+    
+    # Summary
+    logger.info(f"\n📊 Health Validation Check Results:")
+    logger.info(f"   Found validation checks: {len(found_checks)}/{len(health_validation_checks)}")
+    logger.info(f"   Correct operation order: {order_correct}")
+    
+    if len(found_checks) >= 4 and order_correct:
+        logger.info("🎉 Health validation fix is properly implemented!")
+        return True
+    else:
+        logger.error("💥 Health validation fix is incomplete or missing!")
+        return False
+
+
+def test_decommission_strategy_behavior():
+    """Test that decommission strategy behavior is correct."""
+    
+    logger.info("\n🔍 Checking decommission strategy implementation...")
+    
+    # Get the _execute_decommission_strategy method source code
+    decommission_method = getattr(CrateDBActivities, '_execute_decommission_strategy', None)
+    
+    if not decommission_method:
+        logger.error("❌ _execute_decommission_strategy method not found!")
+        return False
+    
+    try:
+        source_code = inspect.getsource(decommission_method)
+    except OSError:
+        logger.error("❌ Could not get source code for _execute_decommission_strategy method!")
+        return False
+    
+    # Check for correct dc_util behavior
+    dc_util_checks = [
+        "if cluster.has_dc_util:",
+        "PreStop hook",
+        "Nothing to do here",
+        "_execute_manual_decommission",
+    ]
+    
+    found_dc_util_checks = []
+    for check in dc_util_checks:
+        if check in source_code:
+            found_dc_util_checks.append(check)
+            logger.info(f"✅ Found dc_util logic: '{check}'")
+    
+    if len(found_dc_util_checks) >= 3:
+        logger.info("✅ Decommission strategy logic is correct")
+        return True
+    else:
+        logger.error("❌ Decommission strategy logic is incomplete")
+        return False
+
+
+def main():
+    """Run all validation tests."""
+    
+    logger.info("🧪 Running health validation fix verification...")
+    logger.info("=" * 60)
+    
+    # Run tests
+    health_validation_ok = test_health_validation_exists()
+    decommission_strategy_ok = test_decommission_strategy_behavior()
+    
+    # Final summary
+    logger.info("\n" + "=" * 60)
+    logger.info("📋 FINAL VERIFICATION RESULTS:")
+    logger.info(f"   Health validation fix: {'✅ PASS' if health_validation_ok else '❌ FAIL'}")
+    logger.info(f"   Decommission strategy:  {'✅ PASS' if decommission_strategy_ok else '❌ FAIL'}")
+    
+    if health_validation_ok and decommission_strategy_ok:
+        logger.info("\n🎉 SUCCESS: Health validation regression fix is properly implemented!")
+        logger.info("\n🔒 SECURITY: Pods will no longer be deleted when cluster is not GREEN")
+        logger.info("\n✅ The regression has been fixed:")
+        logger.info("   - Cluster health is validated before each pod restart")
+        logger.info("   - Only GREEN clusters allow pod restarts to proceed")
+        logger.info("   - Non-GREEN clusters (YELLOW, RED, UNKNOWN) block pod restarts")
+        logger.info("   - Health check failures prevent pod deletion")
+        return True
+    else:
+        logger.error("\n💥 FAILURE: Health validation fix is not properly implemented!")
+        logger.error("\n⚠️  WARNING: The regression may still exist!")
+        logger.error("   - Pods might still be deleted when cluster is not GREEN")
+        logger.error("   - Manual review of the implementation is required")
+        return False
+
+
+if __name__ == "__main__":
+    success = main()
+    sys.exit(0 if success else 1)


### PR DESCRIPTION
## Decommission
CrateDB decommission capabilities into the Temporal workflow system. The implementation automatically detects whether a cluster has Kubernetes-managed decommission (preStop hook with dc_util) or requires manual decommission, then executes the appropriate strategy.

## dc_util_timeout
 Implements  `dc_util_timeout` and `min_availability` settings from `maintenance-windows.toml` into the cluster restart workflow. These changes ensure that manual decommission operations use the correct timeout values and availability requirements as configured per cluster.

## Example Configuration

```toml
[production-cluster]
timezone = "UTC"
min_window_duration = 60
dc_util_timeout = 1200         # 20 minutes for production
min_availability = "PRIMARIES"

[[production-cluster.windows]]
time = "02:00-04:00"
weekdays = ["sat", "sun"]
description = "Weekend maintenance"

[development-cluster]
timezone = "UTC"
min_window_duration = 15
dc_util_timeout = 600     # 10 minutes for dev
min_availability = "NONE" # Less strict for development

[[development-cluster.windows]]
time = "12:00-13:00"
weekdays = ["mon", "tue", "wed", "thu", "fri"]
description = "Lunch break maintenance"
```