### PR TITLE
Add cluster routing reset after manual decommission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Maintenance window management with signal-based overrides
 - Dictionary access fixes for Temporal activity results
 - Comprehensive legacy code cleanup
+- **Enhanced Cluster Routing Allocation Reset**: Automatic reset of `cluster.routing.allocation.enable` setting to "all" after pod restarts when using manual decommission
+  - Reset executes independently of cluster health state (GREEN/YELLOW/RED) 
+  - Reset occurs even if pod restart operations fail
+  - Improved timing: waits for CrateDB startup and pod readiness before attempting reset
+  - Retry mechanism: up to 5 attempts with exponential backoff (15s, 30s, 45s, 60s intervals)
+  - Fallback mechanism tries alternative pods if target pod is unavailable
+  - Critical error logging with manual intervention instructions when all attempts fail
 
 ### Changed
 - Fixed AttributeError issues with activity results being accessed as objects instead of dictionaries
@@ -44,6 +51,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed 'dict' object has no attribute 'is_valid' error in cluster validation
 - Fixed 'dict' object has no attribute 'health_status' error in health checks
 - Fixed 'PodRestartResult' object is not subscriptable error in pod restart workflows
+- Fixed cluster routing allocation setting not being reset after manual decommission and pod restart
+- Enhanced cluster routing reset to work independently of cluster health and operation success/failure
+- Improved cluster routing reset timing to wait for CrateDB readiness before attempting reset
+- Added retry mechanism with exponential backoff for cluster routing reset operations
+- Added fallback mechanism for routing reset when target pod is unavailable
+- Fixed random.uniform usage in HealthCheckStateMachine workflow (replaced with deterministic jitter)
 
 ## [0.1.1] - 2025-01-30
 

--- a/rr/models.py
+++ b/rr/models.py
@@ -100,6 +100,28 @@ class HealthCheckInput(BaseModel):
     timeout: int = 300
 
 
+class ClusterRoutingResetInput(BaseModel):
+    """Input for cluster routing allocation reset activity."""
+    
+    pod_name: str
+    namespace: str
+    cluster: CrateDBCluster
+    dry_run: bool = False
+
+
+class ClusterRoutingResetResult(BaseModel):
+    """Result of cluster routing allocation reset activity."""
+    
+    pod_name: str
+    namespace: str
+    cluster_name: str
+    success: bool
+    duration: float
+    error: Optional[str] = None
+    started_at: Optional[datetime] = None
+    completed_at: Optional[datetime] = None
+
+
 class HealthCheckResult(BaseModel):
     """Result of health check activity."""
     

--- a/rr/worker.py
+++ b/rr/worker.py
@@ -80,6 +80,7 @@ class WorkerManager:
                 activities.decommission_pod,
                 activities.delete_pod,
                 activities.wait_for_pod_ready,
+                activities.reset_cluster_routing_allocation,
             ],
             # Configure worker options for development
             max_concurrent_activities=5,


### PR DESCRIPTION
In case of a manual "decommission", the scripts sets _routing.allocation_ to `NEW_PRIMARIES`. The intention of this is to keep shard moving during the reboot of a node to a minimum. 
But it needs to be _RESET_ to `NONE`, otherwise the cluster might not return to `GREEN` at all. Up to cratedb `5.10.x` the behavior was bit different.