### PR TITLE
Add suspended nodes feature with Node detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -235,3 +235,5 @@ scratch_*.py
 # Test result files
 test_results/
 *.test.log
+
+zed/

--- a/SUSPENDED_NODES_FEATURE.md
+++ b/SUSPENDED_NODES_FEATURE.md
@@ -1,0 +1,127 @@
+# Suspended Nodes Feature Summary
+
+## Overview
+
+The `--only-on-suspended-nodes` feature allows selective restart of CrateDB pods that are running on suspended Kubernetes nodes. This feature provides a robust, lightweight solution for handling node maintenance, spot instance terminations, and other scenarios where specific nodes need to be drained gracefully.
+
+## Key Features
+
+- **Selective Pod Restart**: Only restarts pods on suspended nodes, leaving others untouched
+- **Comprehensive Detection**: Detects suspended nodes via multiple criteria (taints, annotations, unschedulable flag)
+- **Temporal Integration**: Leverages Temporal's retry policies and state management
+- **Robust Error Handling**: Gracefully handles failures with conservative defaults
+- **Detailed Logging**: Provides clear visibility into which pods are processed vs skipped
+
+## Usage
+
+```bash
+# Basic usage - restart pods on suspended nodes only
+rr restart --context prod --only-on-suspended-nodes cluster1
+
+# With dry run to preview actions
+rr restart --context prod --only-on-suspended-nodes --dry-run cluster1
+
+# For all clusters (with confirmation)
+rr restart --context prod --only-on-suspended-nodes all
+
+# Asynchronous execution for large clusters
+rr restart --context prod --only-on-suspended-nodes --async cluster1
+```
+
+## Implementation Details
+
+### Architecture
+- **CLI Layer**: New `--only-on-suspended-nodes` flag in `cli.py`
+- **Model Layer**: `RestartOptions.only_on_suspended_nodes` field
+- **Activity Layer**: `is_pod_on_suspended_node()` activity for node status detection
+- **State Machine**: Modified `ClusterRestartStateMachine` to skip pods on active nodes
+
+### Node Suspension Detection
+A node is considered suspended if it has any of:
+- `spec.unschedulable: true`
+- Suspension taints: `node.kubernetes.io/unschedulable`, `aws.amazon.com/spot-instance-terminating`, etc.
+- Suspension annotations: `node.kubernetes.io/suspend`, `cluster-autoscaler.kubernetes.io/scale-down-disabled`, etc.
+
+### Workflow Integration
+1. **Pod Discovery**: Normal cluster discovery process
+2. **Node Check**: For each pod, check if its node is suspended
+3. **Selective Processing**: Skip pods on active nodes, restart pods on suspended nodes
+4. **Health Checks**: Only perform final health check if pods were actually restarted
+
+## Files Modified
+
+| File | Changes |
+|------|---------|
+| `rr/cli.py` | Added CLI argument and updated function signatures |
+| `rr/models.py` | Added `only_on_suspended_nodes` field to `RestartOptions` |
+| `rr/activities.py` | Added `is_pod_on_suspended_node()` activity |
+| `rr/state_machines.py` | Modified pod restart logic to check node status |
+
+## Testing
+
+Comprehensive test suite includes:
+- **Unit Tests**: Activity functionality and model validation
+- **Integration Tests**: Real-world scenarios with mixed node states
+- **Error Handling**: Graceful degradation on API failures
+- **Edge Cases**: Pods without node assignment, permission errors
+
+Run tests with:
+```bash
+python -m pytest tests/test_suspended_nodes*.py -v
+```
+
+## Security Considerations
+
+The feature requires additional Kubernetes permissions:
+- `nodes/get` - Read individual node status
+- `nodes/list` - List nodes for validation
+
+These are cluster-scoped permissions and should be granted appropriately.
+
+## Best Practices
+
+1. **Test First**: Always use `--dry-run` to preview actions
+2. **Monitor Logs**: Watch for skipped vs restarted pods
+3. **Permission Setup**: Ensure proper RBAC for node access
+4. **Combine Features**: Use with maintenance windows and async execution as needed
+
+## Example Output
+
+```
+[STATE: POD_RESTARTS] Checking pod 1/3: cratedb-0
+[STATE: POD_RESTARTS] Pod cratedb-0 is running on active node worker-1
+[STATE: POD_RESTARTS] Skipping pod cratedb-0 - not on suspended node
+
+[STATE: POD_RESTARTS] Checking pod 2/3: cratedb-1  
+[STATE: POD_RESTARTS] Pod cratedb-1 is running on suspended node worker-2
+[STATE: POD_RESTARTS] Restarting pod 2/3: cratedb-1
+...
+
+[STATE: COMPLETE] Restarted 1 pods, skipped 2 pods
+[STATE: COMPLETE] Skipped pods: cratedb-0, cratedb-2
+```
+
+## Performance Impact
+
+- **Minimal Overhead**: Only adds node status checks when flag is enabled
+- **Efficient API Usage**: Uses direct node/pod API calls rather than broad queries
+- **Temporal Optimization**: Leverages existing retry policies and state management
+- **Conservative Defaults**: Skips pods on API errors to avoid unnecessary operations
+
+## Future Enhancements
+
+Potential improvements could include:
+- Custom node selector criteria
+- Batch node status checks for better performance
+- Integration with cluster autoscaler events
+- Support for custom suspension indicators
+
+## Worker Restart Required
+
+⚠️ **Important**: After upgrading to use this feature, you must restart the Temporal worker to register the new `is_pod_on_suspended_node` activity. 
+
+The worker will fail with `Activity function is_pod_on_suspended_node is not registered` if you try to use the feature without restarting the worker first.
+
+---
+
+This feature provides a production-ready solution for handling node maintenance scenarios while maintaining the existing robustness and reliability of the CrateDB restart workflow.

--- a/demo_suspended_nodes.py
+++ b/demo_suspended_nodes.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+"""
+Demo script showing the suspended nodes feature in action.
+
+This script demonstrates how to use the --only-on-suspended-nodes flag
+and shows the different behaviors with various node states.
+"""
+
+import asyncio
+import sys
+from unittest.mock import Mock, patch
+from datetime import datetime
+
+# Add the parent directory to the path so we can import rr modules
+sys.path.insert(0, '.')
+
+from rr.activities import CrateDBActivities
+from rr.models import CrateDBCluster, RestartOptions
+from kubernetes.client import V1Node, V1NodeSpec, V1Pod, V1PodSpec, V1ObjectMeta, V1Taint
+
+
+def create_demo_cluster():
+    """Create a demo cluster with multiple pods."""
+    return CrateDBCluster(
+        name="demo-cluster",
+        namespace="cratedb-demo",
+        statefulset_name="demo-cluster-sts",
+        health="GREEN",
+        replicas=4,
+        pods=["demo-cluster-0", "demo-cluster-1", "demo-cluster-2", "demo-cluster-3"],
+        has_prestop_hook=True,
+        has_dc_util=True,
+        suspended=False,
+        crd_name="demo-cluster-crd",
+        dc_util_timeout=720,
+        min_availability="PRIMARIES"
+    )
+
+
+def create_mock_pod(pod_name: str, node_name: str):
+    """Create a mock pod object."""
+    pod = Mock(spec=V1Pod)
+    pod.metadata = Mock(spec=V1ObjectMeta)
+    pod.metadata.name = pod_name
+    pod.spec = Mock(spec=V1PodSpec)
+    pod.spec.node_name = node_name
+    return pod
+
+
+def create_mock_node(node_name: str, suspended: bool = False, suspension_type: str = "unschedulable"):
+    """Create a mock node object."""
+    node = Mock(spec=V1Node)
+    node.metadata = Mock(spec=V1ObjectMeta)
+    node.metadata.name = node_name
+    node.metadata.annotations = {}
+    node.spec = Mock(spec=V1NodeSpec)
+    node.spec.taints = []
+    node.spec.unschedulable = False
+    
+    if suspended:
+        if suspension_type == "unschedulable":
+            node.spec.unschedulable = True
+        elif suspension_type == "spot_terminating":
+            taint = Mock(spec=V1Taint)
+            taint.key = "aws.amazon.com/spot-instance-terminating"
+            taint.value = "true"
+            taint.effect = "NoSchedule"
+            node.spec.taints = [taint]
+        elif suspension_type == "annotation":
+            node.metadata.annotations = {"node.kubernetes.io/suspend": "true"}
+        elif suspension_type == "autoscaler":
+            node.metadata.annotations = {"cluster-autoscaler.kubernetes.io/scale-down-disabled": "true"}
+    
+    return node
+
+
+async def demo_node_detection():
+    """Demonstrate node suspension detection."""
+    print("=" * 80)
+    print("🔍 DEMO: Node Suspension Detection")
+    print("=" * 80)
+    
+    activities = CrateDBActivities()
+    
+    # Create demo scenarios
+    scenarios = [
+        ("demo-cluster-0", "worker-1", False, "active"),
+        ("demo-cluster-1", "worker-2", True, "unschedulable"),
+        ("demo-cluster-2", "worker-3", True, "spot_terminating"),
+        ("demo-cluster-3", "worker-4", True, "annotation"),
+    ]
+    
+    with patch.object(activities, '_ensure_kube_client'):
+        with patch.object(activities, 'core_v1') as mock_core_v1:
+            
+            def mock_read_pod(name, namespace):
+                for pod_name, node_name, _, _ in scenarios:
+                    if pod_name == name:
+                        return create_mock_pod(pod_name, node_name)
+                return create_mock_pod(name, "unknown-node")
+            
+            def mock_read_node(name):
+                for pod_name, node_name, suspended, suspension_type in scenarios:
+                    if node_name == name:
+                        return create_mock_node(node_name, suspended, suspension_type)
+                return create_mock_node(name, False)
+            
+            mock_core_v1.read_namespaced_pod.side_effect = mock_read_pod
+            mock_core_v1.read_node.side_effect = mock_read_node
+            
+            print("Checking pod-to-node mappings and suspension status:\n")
+            
+            for pod_name, node_name, expected_suspended, suspension_type in scenarios:
+                print(f"Pod: {pod_name}")
+                print(f"  └── Node: {node_name}")
+                print(f"  └── Expected: {'SUSPENDED' if expected_suspended else 'ACTIVE'}")
+                
+                result = await activities.is_pod_on_suspended_node(pod_name, "cratedb-demo")
+                
+                status = "✅ SUSPENDED" if result else "❌ ACTIVE"
+                print(f"  └── Detected: {status}")
+                
+                if expected_suspended and suspension_type != "active":
+                    print(f"  └── Reason: {suspension_type}")
+                
+                print()
+
+
+async def demo_restart_behavior():
+    """Demonstrate restart behavior with suspended nodes flag."""
+    print("=" * 80)
+    print("🔄 DEMO: Restart Behavior Comparison")
+    print("=" * 80)
+    
+    cluster = create_demo_cluster()
+    
+    print("Cluster Configuration:")
+    print(f"  Name: {cluster.name}")
+    print(f"  Namespace: {cluster.namespace}")
+    print(f"  Pods: {', '.join(cluster.pods)}")
+    print()
+    
+    # Scenario 1: Normal restart (all pods)
+    print("📋 Scenario 1: Normal Restart (--only-on-suspended-nodes=False)")
+    print("  Would restart ALL pods:")
+    for pod in cluster.pods:
+        print(f"    ✓ {pod}")
+    print()
+    
+    # Scenario 2: Suspended nodes only
+    print("📋 Scenario 2: Suspended Nodes Only (--only-on-suspended-nodes=True)")
+    print("  Would restart ONLY pods on suspended nodes:")
+    
+    suspended_pods = ["demo-cluster-1", "demo-cluster-2", "demo-cluster-3"]
+    active_pods = ["demo-cluster-0"]
+    
+    for pod in suspended_pods:
+        print(f"    ✓ {pod} (on suspended node)")
+    
+    print("  Would SKIP pods on active nodes:")
+    for pod in active_pods:
+        print(f"    ⏭️  {pod} (on active node)")
+    print()
+
+
+def demo_cli_usage():
+    """Demonstrate CLI usage examples."""
+    print("=" * 80)
+    print("💻 DEMO: CLI Usage Examples")
+    print("=" * 80)
+    
+    examples = [
+        {
+            "title": "Basic Usage",
+            "command": "rr restart --context prod --only-on-suspended-nodes cluster1",
+            "description": "Restart pods on suspended nodes only"
+        },
+        {
+            "title": "Dry Run",
+            "command": "rr restart --context prod --only-on-suspended-nodes --dry-run cluster1",
+            "description": "Preview which pods would be restarted"
+        },
+        {
+            "title": "All Clusters",
+            "command": "rr restart --context prod --only-on-suspended-nodes all",
+            "description": "Apply to all clusters (with confirmation)"
+        },
+        {
+            "title": "Asynchronous",
+            "command": "rr restart --context prod --only-on-suspended-nodes --async cluster1",
+            "description": "Start workflow asynchronously"
+        },
+        {
+            "title": "With Maintenance Windows",
+            "command": "rr restart --context prod --only-on-suspended-nodes --maintenance-config windows.toml cluster1",
+            "description": "Respect maintenance windows"
+        },
+        {
+            "title": "Debug Mode",
+            "command": "rr restart --context prod --only-on-suspended-nodes --log-level DEBUG cluster1",
+            "description": "Enable detailed logging"
+        }
+    ]
+    
+    for example in examples:
+        print(f"📝 {example['title']}:")
+        print(f"   Command: {example['command']}")
+        print(f"   Purpose: {example['description']}")
+        print()
+
+
+def demo_options_model():
+    """Demonstrate the RestartOptions model."""
+    print("=" * 80)
+    print("⚙️  DEMO: Configuration Options")
+    print("=" * 80)
+    
+    # Default options
+    default_options = RestartOptions(context="prod")
+    print("Default Options:")
+    print(f"  only_on_suspended_nodes: {default_options.only_on_suspended_nodes}")
+    print(f"  dry_run: {default_options.dry_run}")
+    print(f"  context: {default_options.context}")
+    print()
+    
+    # Suspended nodes enabled
+    suspended_options = RestartOptions(
+        context="prod",
+        only_on_suspended_nodes=True,
+        dry_run=True,
+        log_level="DEBUG"
+    )
+    print("Suspended Nodes Options:")
+    print(f"  only_on_suspended_nodes: {suspended_options.only_on_suspended_nodes}")
+    print(f"  dry_run: {suspended_options.dry_run}")
+    print(f"  log_level: {suspended_options.log_level}")
+    print()
+    
+    # Serialization demo
+    options_dict = suspended_options.model_dump()
+    print("Serialized Options:")
+    for key, value in options_dict.items():
+        if key in ['only_on_suspended_nodes', 'dry_run', 'context', 'log_level']:
+            print(f"  {key}: {value}")
+    print()
+
+
+def demo_real_world_scenarios():
+    """Demonstrate real-world scenarios."""
+    print("=" * 80)
+    print("🌍 DEMO: Real-World Scenarios")
+    print("=" * 80)
+    
+    scenarios = [
+        {
+            "name": "AWS Spot Instance Termination",
+            "description": "Handle spot instance termination gracefully",
+            "detection": "aws.amazon.com/spot-instance-terminating taint",
+            "command": "rr restart --context prod --only-on-suspended-nodes --async all",
+            "benefit": "Proactively restart pods before instance termination"
+        },
+        {
+            "name": "Planned Node Maintenance",
+            "description": "Coordinate with cluster maintenance",
+            "detection": "node.kubernetes.io/unschedulable flag",
+            "command": "rr restart --context prod --only-on-suspended-nodes --maintenance-config maintenance.toml cluster1",
+            "benefit": "Respect maintenance windows while handling node drainage"
+        },
+        {
+            "name": "Cluster Autoscaler Scale-Down",
+            "description": "Work with cluster autoscaler",
+            "detection": "cluster-autoscaler.kubernetes.io/scale-down-disabled annotation",
+            "command": "rr restart --context prod --only-on-suspended-nodes --dry-run all",
+            "benefit": "Preview impact before actual scale-down"
+        },
+        {
+            "name": "Emergency Node Evacuation",
+            "description": "Quickly evacuate failing nodes",
+            "detection": "node.kubernetes.io/suspend annotation",
+            "command": "rr restart --context prod --only-on-suspended-nodes --ignore-maintenance-windows cluster1",
+            "benefit": "Bypass maintenance windows for emergency situations"
+        }
+    ]
+    
+    for i, scenario in enumerate(scenarios, 1):
+        print(f"📊 Scenario {i}: {scenario['name']}")
+        print(f"   Description: {scenario['description']}")
+        print(f"   Detection: {scenario['detection']}")
+        print(f"   Command: {scenario['command']}")
+        print(f"   Benefit: {scenario['benefit']}")
+        print()
+
+
+async def main():
+    """Run all demonstrations."""
+    print("🚀 CrateDB Suspended Nodes Feature Demo")
+    print(f"⏰ Started at: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+    print()
+    
+    try:
+        await demo_node_detection()
+        await demo_restart_behavior()
+        demo_cli_usage()
+        demo_options_model()
+        demo_real_world_scenarios()
+        
+        print("=" * 80)
+        print("✅ Demo completed successfully!")
+        print("=" * 80)
+        print()
+        print("Next Steps:")
+        print("1. ⚠️  RESTART THE TEMPORAL WORKER to register the new activity")
+        print("2. Try the CLI commands with your own clusters")
+        print("3. Test with --dry-run first to see the behavior")
+        print("4. Monitor logs to understand pod selection")
+        print("5. Set up appropriate RBAC permissions for node access")
+        print()
+        print("⚠️  Important: The worker must be restarted after upgrading to use this feature.")
+        print("    Otherwise you'll get: 'Activity function is_pod_on_suspended_node is not registered'")
+        print()
+        
+    except Exception as e:
+        print(f"❌ Demo failed: {e}")
+        return 1
+    
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/docs/suspended-nodes-feature.md
+++ b/docs/suspended-nodes-feature.md
@@ -1,0 +1,174 @@
+# Suspended Nodes Feature
+
+This document describes the `--only-on-suspended-nodes` feature for the CrateDB cluster restart tool.
+
+## Overview
+
+The `--only-on-suspended-nodes` flag allows you to restart only the CrateDB pods that are running on suspended Kubernetes nodes. This is useful for scenarios where you want to gracefully handle node maintenance, spot instance terminations, or other situations where specific nodes are marked for removal.
+
+## Usage
+
+```bash
+rr restart --context prod --only-on-suspended-nodes cluster1
+```
+
+## How It Works
+
+When the `--only-on-suspended-nodes` flag is enabled, the restart workflow performs the following steps:
+
+1. **Pod Discovery**: Discovers all pods in the specified CrateDB cluster(s)
+2. **Node Status Check**: For each pod, checks if it's running on a suspended node
+3. **Selective Restart**: Only restarts pods that are running on suspended nodes
+4. **Logging**: Logs detailed information about skipped and restarted pods
+
+## Node Suspension Detection
+
+A node is considered "suspended" if it has any of the following characteristics:
+
+### Unschedulable Flag
+- Node has `spec.unschedulable: true`
+
+### Suspension Taints
+- `node.kubernetes.io/unschedulable`
+- `node.kubernetes.io/not-ready`
+- `node.kubernetes.io/unreachable`
+- `aws.amazon.com/spot-instance-terminating`
+- `cluster-autoscaler.kubernetes.io/scale-down-disabled`
+- `node.kubernetes.io/suspend`
+
+### Suspension Annotations
+- `cluster-autoscaler.kubernetes.io/scale-down-disabled`
+- `node.kubernetes.io/suspend`
+- `node.kubernetes.io/suspended`
+
+## Behavior
+
+### When Pods Are on Suspended Nodes
+- Pod is restarted following the normal restart workflow
+- Decommissioning, deletion, and health checks are performed
+- Logging indicates the pod was restarted
+
+### When Pods Are on Active Nodes
+- Pod is skipped entirely
+- No decommissioning or restart operations are performed
+- Logging indicates the pod was skipped with the reason
+
+### Error Handling
+- If node status cannot be determined, the pod is skipped for safety
+- Errors are logged but don't fail the entire operation
+- Conservative approach prioritizes cluster stability
+
+## Example Output
+
+```
+[STATE: POD_RESTARTS] Checking pod 1/3: cratedb-cluster-0
+[STATE: POD_RESTARTS] Pod cratedb-cluster-0 is running on active node worker-1
+[STATE: POD_RESTARTS] Skipping pod cratedb-cluster-0 - not on suspended node
+
+[STATE: POD_RESTARTS] Checking pod 2/3: cratedb-cluster-1
+[STATE: POD_RESTARTS] Pod cratedb-cluster-1 is running on suspended node worker-2
+[STATE: POD_RESTARTS] Pod cratedb-cluster-1 is on suspended node, proceeding with restart
+[STATE: POD_RESTARTS] Restarting pod 2/3: cratedb-cluster-1
+[STATE: DECOMMISSION] Decommissioning pod cratedb-cluster-1
+...
+
+[STATE: COMPLETE] Cluster restart completed for cratedb-cluster in 45.2s
+[STATE: COMPLETE] Restarted 1 pods, skipped 2 pods
+[STATE: COMPLETE] Skipped pods: cratedb-cluster-0, cratedb-cluster-2
+```
+
+## Use Cases
+
+### Spot Instance Termination
+Handle AWS spot instance termination gracefully:
+```bash
+rr restart --context prod --only-on-suspended-nodes --async all
+```
+
+### Planned Node Maintenance
+Restart pods before planned node maintenance:
+```bash
+rr restart --context prod --only-on-suspended-nodes cluster1 cluster2
+```
+
+### Node Draining
+Coordinate with cluster autoscaler node draining:
+```bash
+rr restart --context prod --only-on-suspended-nodes --dry-run all
+```
+
+## Integration with Temporal
+
+The suspended nodes feature integrates seamlessly with Temporal workflows:
+
+- **Reliability**: Uses Temporal's retry policies for node status checks
+- **Observability**: All operations are logged and tracked through Temporal
+- **State Management**: Maintains proper state transitions through the restart workflow
+- **Error Recovery**: Temporal handles transient failures in node status detection
+
+## Limitations
+
+1. **Node Status Accuracy**: Depends on accurate node status in Kubernetes API
+2. **Timing**: Node status is checked at the beginning of each pod restart
+3. **Permissions**: Requires cluster-level permissions to read node status
+4. **Static Check**: Node status is not re-checked during the restart process
+
+## Best Practices
+
+1. **Combine with Dry Run**: Use `--dry-run` first to see which pods would be affected
+2. **Monitor Logs**: Watch the logs to ensure expected pods are being processed
+3. **Use with Async**: For large clusters, consider using `--async` to avoid blocking
+4. **Test Permissions**: Ensure the service account has node read permissions
+
+## Security Considerations
+
+The feature requires additional Kubernetes permissions:
+- `nodes/get` - Read individual node status
+- `nodes/list` - List nodes (for validation)
+
+These permissions are cluster-scoped and should be granted carefully.
+
+## Troubleshooting
+
+### Common Issues
+
+**Pod always skipped despite node being suspended:**
+- Check if the node has the expected taints/annotations
+- Verify the pod is actually scheduled on the suspected node
+- Enable debug logging with `--log-level DEBUG`
+
+**Permission errors:**
+- Ensure the service account has `nodes/get` permissions
+- Check if RBAC policies allow node access
+
+**False positives:**
+- Review the node suspension detection criteria
+- Some cloud providers may use different taint keys
+
+### Debug Commands
+
+Check pod node assignment:
+```bash
+kubectl get pod -n <namespace> <pod-name> -o jsonpath='{.spec.nodeName}'
+```
+
+Check node status:
+```bash
+kubectl get node <node-name> -o yaml
+```
+
+Check node taints:
+```bash
+kubectl describe node <node-name> | grep -A 10 Taints
+```
+
+## Worker Restart Required
+
+⚠️ **Important**: After upgrading to use this feature, you must restart the Temporal worker to register the new `is_pod_on_suspended_node` activity. 
+
+The worker will fail with `Activity function is_pod_on_suspended_node is not registered` if you try to use the feature without restarting the worker first.
+
+To restart the worker:
+1. Stop the current worker process
+2. Start the worker again with the updated code
+3. Verify the new activity is registered in the worker logs

--- a/rr/cli.py
+++ b/rr/cli.py
@@ -176,7 +176,7 @@ def generate_report(result, output_format: str = "text") -> str:
 
 async def async_main(cluster_names, kubeconfig, context, dry_run, skip_hook_warning,
                     output_format, log_level, temporal_address, task_queue, async_execution,
-                    maintenance_config, ignore_maintenance_windows):
+                    maintenance_config, ignore_maintenance_windows, only_on_suspended_nodes):
     """Async main function that handles the Temporal workflow execution."""
     current_log_level = setup_logging(log_level)
 
@@ -238,6 +238,7 @@ async def async_main(cluster_names, kubeconfig, context, dry_run, skip_hook_warn
             log_level=log_level,
             maintenance_config_path=maintenance_config,
             ignore_maintenance_windows=ignore_maintenance_windows,
+            only_on_suspended_nodes=only_on_suspended_nodes,
         )
 
         # Connect to Temporal
@@ -404,9 +405,14 @@ def cli(ctx):
     is_flag=True,
     help="Ignore maintenance windows and proceed with restart immediately",
 )
+@click.option(
+    "--only-on-suspended-nodes",
+    is_flag=True,
+    help="Only restart pods running on suspended Kubernetes nodes",
+)
 def restart(cluster_names, kubeconfig, context, dry_run, skip_hook_warning, 
            output_format, log_level, temporal_address, task_queue, async_execution,
-           maintenance_config, ignore_maintenance_windows):
+           maintenance_config, ignore_maintenance_windows, only_on_suspended_nodes):
     """Restart CrateDB clusters with Temporal workflows.
 
     CLUSTER_NAMES: Space-separated list of CrateDB cluster names to restart.
@@ -419,12 +425,13 @@ def restart(cluster_names, kubeconfig, context, dry_run, skip_hook_warning,
       rr restart --context prod --async cluster1         # Start restart asynchronously
       rr restart --context prod --maintenance-config maintenance-windows.toml cluster1  # Use maintenance windows
       rr restart --context prod --ignore-maintenance-windows cluster1  # Ignore maintenance windows
+      rr restart --context prod --only-on-suspended-nodes cluster1  # Only restart pods on suspended nodes
     """
     
     asyncio.run(async_main(
         cluster_names, kubeconfig, context, dry_run, skip_hook_warning,
         output_format, log_level, temporal_address, task_queue, async_execution,
-        maintenance_config, ignore_maintenance_windows
+        maintenance_config, ignore_maintenance_windows, only_on_suspended_nodes
     ))
 
 

--- a/rr/models.py
+++ b/rr/models.py
@@ -38,6 +38,7 @@ class RestartOptions(BaseModel):
     health_check_timeout: int = 300
     maintenance_config_path: Optional[str] = None
     ignore_maintenance_windows: bool = False
+    only_on_suspended_nodes: bool = False
 
 
 class RestartResult(BaseModel):

--- a/rr/worker.py
+++ b/rr/worker.py
@@ -81,6 +81,7 @@ class WorkerManager:
                 activities.delete_pod,
                 activities.wait_for_pod_ready,
                 activities.reset_cluster_routing_allocation,
+                activities.is_pod_on_suspended_node,
             ],
             # Configure worker options for development
             max_concurrent_activities=5,

--- a/tests/test_cluster_routing_reset.py
+++ b/tests/test_cluster_routing_reset.py
@@ -1,0 +1,411 @@
+#!/usr/bin/env python3
+"""
+Tests for cluster routing allocation reset functionality.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, Mock, patch
+import json
+
+from rr.activities import CrateDBActivities
+from rr.models import PodRestartInput, CrateDBCluster, ClusterRoutingResetInput
+
+
+@pytest.fixture
+def mock_cratedb_activities():
+    """Create a CrateDBActivities instance with mocked Kubernetes clients."""
+    activities = CrateDBActivities()
+    activities.core_v1 = Mock()
+    activities.apps_v1 = Mock()
+    activities.custom_objects_api = Mock()
+    return activities
+
+
+@pytest.fixture
+def manual_decommission_cluster():
+    """Create a cluster configured for manual decommission."""
+    return CrateDBCluster(
+        name="test-cluster",
+        namespace="test-namespace",
+        statefulset_name="test-sts",
+        health="GREEN",
+        replicas=1,
+        crd_name="test-cluster-crd",
+        pods=["test-pod-0"],
+        has_prestop_hook=False,
+        has_dc_util=False,  # This triggers manual decommission
+        dc_util_timeout=300,
+        min_availability="PRIMARIES"
+    )
+
+
+@pytest.fixture
+def kubernetes_decommission_cluster():
+    """Create a cluster configured for Kubernetes-managed decommission."""
+    return CrateDBCluster(
+        name="test-cluster",
+        namespace="test-namespace",
+        statefulset_name="test-sts",
+        health="GREEN",
+        replicas=1,
+        crd_name="test-cluster-crd",
+        pods=["test-pod-0"],
+        has_prestop_hook=True,
+        has_dc_util=True,  # This uses Kubernetes-managed decommission
+        dc_util_timeout=300,
+        min_availability="PRIMARIES"
+    )
+
+
+class TestClusterRoutingAllocationReset:
+    """Test cases for cluster routing allocation reset functionality."""
+
+    @pytest.mark.asyncio
+    async def test_reset_cluster_routing_allocation_success(self, mock_cratedb_activities):
+        """Test successful reset of cluster routing allocation setting."""
+        # Mock the command execution
+        mock_cratedb_activities._execute_command_in_pod = AsyncMock(
+            return_value='{"rows":[],"rowcount":0,"duration":0.123}'
+        )
+        
+        # Create a mock cluster
+        mock_cluster = Mock()
+        mock_cluster.pods = ["test-pod-0", "test-pod-1"]
+        
+        # Execute the reset
+        await mock_cratedb_activities._reset_cluster_routing_allocation(
+            "test-pod-0", 
+            "test-namespace",
+            mock_cluster
+        )
+        
+        # Verify the command was called with correct parameters
+        mock_cratedb_activities._execute_command_in_pod.assert_called_once()
+        call_args = mock_cratedb_activities._execute_command_in_pod.call_args
+        
+        pod_name, namespace, command = call_args[0]
+        assert pod_name == "test-pod-0"
+        assert namespace == "test-namespace"
+        
+        # Verify the command contains the correct SQL
+        expected_sql = 'set global transient "cluster.routing.allocation.enable" = "all"'
+        # The SQL is JSON-escaped in the command, so check for the escaped version
+        assert '\\"cluster.routing.allocation.enable\\" = \\"all\\"' in command
+        assert "application/json" in command
+        assert "https://127.0.0.1:4200/_sql" in command
+
+    @pytest.mark.asyncio
+    async def test_reset_cluster_routing_allocation_failure(self, mock_cratedb_activities):
+        """Test that reset failure raises exception (to be caught by retry wrapper)."""
+        # Mock the command execution to fail
+        mock_cratedb_activities._execute_command_in_pod = AsyncMock(
+            side_effect=Exception("Connection failed")
+        )
+        
+        # Create a mock cluster
+        mock_cluster = Mock()
+        mock_cluster.pods = ["test-pod-0", "test-pod-1"]
+        
+        # Execute the reset - should raise exception (for retry wrapper to catch)
+        with pytest.raises(Exception, match="All reset attempts failed"):
+            await mock_cratedb_activities._reset_cluster_routing_allocation(
+                "test-pod-0", 
+                "test-namespace",
+                mock_cluster
+            )
+
+    @pytest.mark.asyncio
+    async def test_reset_cluster_routing_allocation_activity_success(self, mock_cratedb_activities, manual_decommission_cluster):
+        """Test the new separate reset_cluster_routing_allocation activity."""
+        # Mock the underlying reset method
+        mock_cratedb_activities._reset_cluster_routing_allocation = AsyncMock()
+        
+        # Create input for the new activity
+        reset_input = ClusterRoutingResetInput(
+            pod_name="test-pod-0",
+            namespace="test-namespace",
+            cluster=manual_decommission_cluster,
+            dry_run=False
+        )
+        
+        # Mock sleep to speed up test
+        with patch('asyncio.sleep'):
+            # Execute the reset activity
+            result = await mock_cratedb_activities.reset_cluster_routing_allocation(reset_input)
+        
+        # Verify the result
+        assert result.success is True
+        assert result.pod_name == "test-pod-0"
+        assert result.namespace == "test-namespace"
+        assert result.cluster_name == manual_decommission_cluster.name
+        assert result.error is None
+        
+        # Verify underlying reset method was called
+        mock_cratedb_activities._reset_cluster_routing_allocation.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_reset_cluster_routing_allocation_activity_failure(self, mock_cratedb_activities, manual_decommission_cluster):
+        """Test that reset activity raises exception when underlying reset fails."""
+        # Mock the underlying reset method to fail
+        mock_cratedb_activities._reset_cluster_routing_allocation = AsyncMock(
+            side_effect=Exception("CrateDB connection failed")
+        )
+        
+        # Create input for the new activity
+        reset_input = ClusterRoutingResetInput(
+            pod_name="test-pod-0",
+            namespace="test-namespace",
+            cluster=manual_decommission_cluster,
+            dry_run=False
+        )
+        
+        # Mock sleep to speed up test
+        with patch('asyncio.sleep'):
+            # Execute the reset activity - should raise exception for Temporal to retry
+            with pytest.raises(Exception, match="Failed to reset cluster routing allocation"):
+                await mock_cratedb_activities.reset_cluster_routing_allocation(reset_input)
+        
+        # Verify underlying reset method was called
+        mock_cratedb_activities._reset_cluster_routing_allocation.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_restart_pod_no_longer_calls_reset_directly(self, mock_cratedb_activities, manual_decommission_cluster):
+        """Test that restart_pod no longer calls reset directly (now handled by state machine)."""
+        # Mock all the dependencies
+        mock_cratedb_activities.check_cluster_health = AsyncMock(
+            return_value=Mock(is_healthy=True, health_status="GREEN")
+        )
+        mock_cratedb_activities._execute_decommission_strategy = AsyncMock()
+        mock_cratedb_activities._wait_for_pod_ready = AsyncMock()
+        mock_cratedb_activities._reset_cluster_routing_allocation_with_retry = AsyncMock()
+        
+        # Mock pod deletion
+        with patch('asyncio.to_thread') as mock_to_thread:
+            mock_to_thread.return_value = None
+            
+            input_data = PodRestartInput(
+                pod_name="test-pod-0",
+                namespace="test-namespace",
+                cluster=manual_decommission_cluster,
+                pod_ready_timeout=600
+            )
+            
+            # Execute restart_pod
+            result = await mock_cratedb_activities.restart_pod(input_data)
+            
+            # Verify that reset is NOT called directly from restart_pod anymore
+            mock_cratedb_activities._reset_cluster_routing_allocation_with_retry.assert_not_called()
+            
+            # Verify that restart succeeded (reset is now handled by state machine)
+            assert result.success is True
+
+    def test_reset_sql_command_format(self):
+        """Test that the SQL command is properly formatted."""
+        expected_sql = 'set global transient "cluster.routing.allocation.enable" = "all"'
+        expected_json = json.dumps({"stmt": expected_sql})
+        
+        # Verify JSON is valid
+        parsed = json.loads(expected_json)
+        assert parsed["stmt"] == expected_sql
+        
+        # Verify the SQL statement format
+        assert "set global transient" in expected_sql
+        assert '"cluster.routing.allocation.enable"' in expected_sql
+        assert '"all"' in expected_sql
+
+    @pytest.mark.asyncio
+    async def test_temporal_execution_guarantees_for_reset(self, mock_cratedb_activities, manual_decommission_cluster):
+        """Test that reset activity fails until successful, simulating Temporal retry behavior."""
+        attempt_count = 0
+        
+        async def mock_reset_fails_until_third_attempt(*args, **kwargs):
+            nonlocal attempt_count
+            attempt_count += 1
+            if attempt_count < 3:
+                raise Exception("CrateDB not ready yet")
+            # Success on 3rd attempt
+            return
+        
+        mock_cratedb_activities._reset_cluster_routing_allocation = mock_reset_fails_until_third_attempt
+        
+        reset_input = ClusterRoutingResetInput(
+            pod_name="test-pod-0",
+            namespace="test-namespace",
+            cluster=manual_decommission_cluster,
+            dry_run=False
+        )
+        
+        # Mock sleep to speed up test
+        with patch('asyncio.sleep'):
+            # Simulate Temporal retry behavior - first two attempts should fail
+            
+            # First attempt - should fail
+            with pytest.raises(Exception, match="Failed to reset cluster routing allocation"):
+                await mock_cratedb_activities.reset_cluster_routing_allocation(reset_input)
+            
+            # Second attempt - should fail
+            with pytest.raises(Exception, match="Failed to reset cluster routing allocation"):
+                await mock_cratedb_activities.reset_cluster_routing_allocation(reset_input)
+            
+            # Third attempt - should succeed
+            result = await mock_cratedb_activities.reset_cluster_routing_allocation(reset_input)
+        
+        # Verify that the activity succeeded on the third attempt
+        assert result.success is True
+        assert attempt_count == 3  # Temporal would have retried this activity 3 times
+
+    @pytest.mark.asyncio 
+    async def test_state_machine_guarantees_reset_execution(self, mock_cratedb_activities, manual_decommission_cluster):
+        """Test concept: state machine will guarantee reset execution via separate activity."""
+        # This test demonstrates the new architecture where reset is a separate activity
+        # called by the state machine workflow, providing Temporal execution guarantees
+        
+        reset_input = ClusterRoutingResetInput(
+            pod_name="test-pod-0",
+            namespace="test-namespace", 
+            cluster=manual_decommission_cluster,
+            dry_run=False
+        )
+        
+        # Mock underlying reset method
+        mock_cratedb_activities._reset_cluster_routing_allocation = AsyncMock()
+        
+        # Mock sleep to speed up test
+        with patch('asyncio.sleep'):
+            # The state machine would call this activity independently
+            result = await mock_cratedb_activities.reset_cluster_routing_allocation(reset_input)
+        
+        # Verify the activity works independently (no exception means success)
+        assert result.success is True
+        assert result.pod_name == "test-pod-0"
+        
+        # This activity is now called by the state machine workflow, providing:
+        # 1. Temporal execution guarantees (at-least-once execution)
+        # 2. Automatic retries with exponential backoff
+        # 3. Independent execution timeline from pod restart
+
+    @pytest.mark.asyncio
+    async def test_reset_fallback_pod_mechanism(self, mock_cratedb_activities, manual_decommission_cluster):
+        """Test that reset tries fallback pods when target pod fails."""
+        executed_commands = []
+        
+        async def mock_execute_command(pod_name, namespace, command):
+            executed_commands.append(pod_name)
+            if pod_name == "test-pod-0":
+                # Target pod fails
+                raise Exception("Target pod connection failed")
+            else:
+                # Fallback pod succeeds
+                return '{"rows":[],"rowcount":0,"duration":0.123}'
+        
+        # Set up cluster with multiple pods
+        manual_decommission_cluster.pods = ["test-pod-0", "test-pod-1", "test-pod-2"]
+        
+        # Mock the command execution to track which pods are tried
+        mock_cratedb_activities._execute_command_in_pod = mock_execute_command
+        
+        # Execute the reset
+        await mock_cratedb_activities._reset_cluster_routing_allocation(
+            "test-pod-0", 
+            "test-namespace",
+            manual_decommission_cluster
+        )
+        
+        # Verify that both target pod and fallback pod were tried
+        assert "test-pod-0" in executed_commands  # Target pod attempted
+        assert "test-pod-1" in executed_commands  # Fallback pod attempted
+        assert len(executed_commands) == 2  # Exactly two attempts
+
+    @pytest.mark.asyncio
+    async def test_reset_with_retry_mechanism_success(self, mock_cratedb_activities, manual_decommission_cluster):
+        """Test that the internal retry mechanism works when reset eventually succeeds."""
+        attempt_count = 0
+        
+        async def mock_reset(*args, **kwargs):
+            nonlocal attempt_count
+            attempt_count += 1
+            if attempt_count < 3:
+                raise Exception("CrateDB not ready yet")
+            # Success on 3rd attempt
+            return
+        
+        mock_cratedb_activities._reset_cluster_routing_allocation = mock_reset
+        
+        # Mock sleep to speed up test
+        with patch('asyncio.sleep') as mock_sleep:
+            # Execute the retry method directly (this tests the internal retry wrapper)
+            await mock_cratedb_activities._reset_cluster_routing_allocation_with_retry(
+                "test-pod-0",
+                "test-namespace", 
+                manual_decommission_cluster
+            )
+        
+        # Verify retry logic was used
+        assert attempt_count == 3  # Failed twice, succeeded on third attempt
+        assert mock_sleep.call_count >= 2  # Called for initial wait + retries
+
+    @pytest.mark.asyncio
+    async def test_reset_with_retry_mechanism_max_attempts(self, mock_cratedb_activities, manual_decommission_cluster):
+        """Test that internal retry mechanism stops after max attempts."""
+        attempt_count = 0
+        
+        async def mock_reset(*args, **kwargs):
+            nonlocal attempt_count
+            attempt_count += 1
+            raise Exception("CrateDB connection failed")
+        
+        mock_cratedb_activities._reset_cluster_routing_allocation = mock_reset
+        
+        # Mock sleep to speed up test  
+        with patch('asyncio.sleep'):
+            # Execute the retry method directly - should not raise exception
+            await mock_cratedb_activities._reset_cluster_routing_allocation_with_retry(
+                "test-pod-0",
+                "test-namespace",
+                manual_decommission_cluster
+            )
+        
+        # Verify all attempts were made
+        assert attempt_count == 5  # Max attempts reached
+
+    @pytest.mark.asyncio
+    async def test_reset_timing_with_crate_startup_delay(self, mock_cratedb_activities, manual_decommission_cluster):
+        """Test that reset waits for CrateDB startup before attempting reset."""
+        sleep_calls = []
+        
+        async def mock_sleep(duration):
+            sleep_calls.append(duration)
+        
+        mock_cratedb_activities._reset_cluster_routing_allocation = AsyncMock()
+        
+        with patch('asyncio.sleep', side_effect=mock_sleep):
+            await mock_cratedb_activities._reset_cluster_routing_allocation_with_retry(
+                "test-pod-0",
+                "test-namespace",
+                manual_decommission_cluster
+            )
+        
+        # Verify initial wait for CrateDB startup
+        assert 10 in sleep_calls  # Initial 10-second wait for CrateDB startup
+        mock_cratedb_activities._reset_cluster_routing_allocation.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_reset_with_retry_wrapper_never_raises_exception(self, mock_cratedb_activities, manual_decommission_cluster):
+        """Test that the retry wrapper never raises exceptions, even on complete failure."""
+        # Mock the underlying reset to always fail
+        mock_cratedb_activities._reset_cluster_routing_allocation = AsyncMock(
+            side_effect=Exception("Connection failed")
+        )
+        
+        # Mock sleep to speed up test
+        with patch('asyncio.sleep'):
+            # Execute the retry wrapper - should never raise exception
+            try:
+                await mock_cratedb_activities._reset_cluster_routing_allocation_with_retry(
+                    "test-pod-0",
+                    "test-namespace",
+                    manual_decommission_cluster
+                )
+                # Should complete without raising exception
+            except Exception:
+                pytest.fail("_reset_cluster_routing_allocation_with_retry should never raise exceptions")

--- a/tests/test_deterministic_jitter.py
+++ b/tests/test_deterministic_jitter.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""
+Tests for deterministic jitter calculation in state machine workflows.
+
+This ensures that workflows use deterministic values instead of random.uniform
+which is not allowed in Temporal workflows.
+"""
+
+import pytest
+from rr.state_machines import HealthCheckStateMachine
+
+
+class TestDeterministicJitter:
+    """Test cases for deterministic jitter functionality."""
+
+    def test_jitter_calculation_is_deterministic(self):
+        """Test that jitter calculation produces consistent results for same attempt number."""
+        # Test multiple attempt numbers
+        test_cases = [
+            {"attempts": 1, "base_wait": 10},
+            {"attempts": 5, "base_wait": 15},
+            {"attempts": 10, "base_wait": 20},
+            {"attempts": 15, "base_wait": 5},
+        ]
+        
+        for case in test_cases:
+            attempts = case["attempts"]
+            base_wait = case["base_wait"]
+            
+            # Calculate jitter multiple times for same attempt
+            jitter_values = []
+            for _ in range(5):
+                exponential_wait = min(base_wait * (2 ** min(attempts, 10)), 60)
+                jitter_factor = 0.1 + ((attempts % 10) * 0.02)
+                jitter = jitter_factor * exponential_wait
+                jitter_values.append(jitter)
+            
+            # All values should be identical (deterministic)
+            assert all(j == jitter_values[0] for j in jitter_values), \
+                f"Jitter calculation not deterministic for attempts={attempts}, base_wait={base_wait}"
+
+    def test_jitter_factor_range(self):
+        """Test that jitter factor stays within expected range."""
+        for attempts in range(20):  # Test various attempt numbers
+            jitter_factor = 0.1 + ((attempts % 10) * 0.02)
+            
+            # Jitter factor should be between 0.1 and 0.28
+            assert 0.1 <= jitter_factor <= 0.28, \
+                f"Jitter factor {jitter_factor} out of range for attempts={attempts}"
+
+    def test_jitter_increases_with_attempts(self):
+        """Test that jitter generally increases with attempt number (within mod 10 cycle)."""
+        base_wait = 10
+        
+        for cycle_start in [0, 10, 20]:  # Test different cycles
+            jitter_values = []
+            for i in range(10):  # One complete cycle
+                attempts = cycle_start + i
+                exponential_wait = min(base_wait * (2 ** min(attempts, 10)), 60)
+                jitter_factor = 0.1 + ((attempts % 10) * 0.02)
+                jitter = jitter_factor * exponential_wait
+                jitter_values.append(jitter)
+            
+            # Within each cycle, jitter should generally increase
+            # (though exponential_wait may cap at 60, affecting this)
+            for i in range(len(jitter_values) - 1):
+                if jitter_values[i] > 0 and jitter_values[i+1] > 0:
+                    # Allow for exponential wait capping effects
+                    ratio = jitter_values[i+1] / jitter_values[i]
+                    assert ratio >= 0.9, \
+                        f"Jitter not increasing properly: {jitter_values[i]} -> {jitter_values[i+1]}"
+
+    def test_total_wait_calculation(self):
+        """Test complete wait time calculation with deterministic jitter."""
+        test_scenarios = [
+            {"attempts": 1, "base_wait": 10, "expected_min": 22.0, "expected_max": 23.0},  # 20 + (0.12 * 20) = 22.4
+            {"attempts": 3, "base_wait": 5, "expected_min": 46.0, "expected_max": 47.0},  # 40 + (0.16 * 40) = 46.4
+            {"attempts": 8, "base_wait": 15, "expected_min": 75.0, "expected_max": 76.0},  # 60 + (0.26 * 60) = 75.6
+        ]
+        
+        for scenario in test_scenarios:
+            attempts = scenario["attempts"]
+            base_wait = scenario["base_wait"]
+            
+            # Calculate total wait time
+            exponential_wait = min(base_wait * (2 ** min(attempts, 10)), 60)
+            jitter_factor = 0.1 + ((attempts % 10) * 0.02)
+            jitter = jitter_factor * exponential_wait
+            total_wait = exponential_wait + jitter
+            
+            # Verify total wait is in expected range
+            assert scenario["expected_min"] <= total_wait <= scenario["expected_max"], \
+                f"Total wait {total_wait} not in expected range [{scenario['expected_min']}, {scenario['expected_max']}] for attempts={attempts}"
+
+    def test_no_random_imports_in_workflow_files(self):
+        """Test that workflow files don't import random module."""
+        import ast
+        import inspect
+        from rr import state_machines
+        
+        # Get the source code of the state_machines module
+        source = inspect.getsource(state_machines)
+        
+        # Parse the AST
+        tree = ast.parse(source)
+        
+        # Check for random imports
+        random_imports = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    if alias.name == 'random':
+                        random_imports.append(f"import {alias.name}")
+            elif isinstance(node, ast.ImportFrom):
+                if node.module == 'random':
+                    random_imports.append(f"from {node.module} import ...")
+        
+        assert not random_imports, \
+            f"Found random imports in state_machines.py: {random_imports}. " \
+            "Random is not allowed in Temporal workflows as they must be deterministic."
+
+    def test_jitter_reproducibility_across_runs(self):
+        """Test that jitter calculation is reproducible across different runs."""
+        # This simulates what would happen in a workflow replay
+        reference_values = {}
+        
+        # First "run" - calculate reference values
+        for attempts in range(1, 11):
+            base_wait = 10
+            exponential_wait = min(base_wait * (2 ** min(attempts, 10)), 60)
+            jitter_factor = 0.1 + ((attempts % 10) * 0.02)
+            jitter = jitter_factor * exponential_wait
+            total_wait = exponential_wait + jitter
+            reference_values[attempts] = total_wait
+        
+        # Second "run" - should produce identical values
+        for attempts in range(1, 11):
+            base_wait = 10
+            exponential_wait = min(base_wait * (2 ** min(attempts, 10)), 60)
+            jitter_factor = 0.1 + ((attempts % 10) * 0.02)
+            jitter = jitter_factor * exponential_wait
+            total_wait = exponential_wait + jitter
+            
+            assert total_wait == reference_values[attempts], \
+                f"Jitter calculation not reproducible for attempts={attempts}: " \
+                f"first run={reference_values[attempts]}, second run={total_wait}"
+
+    def test_edge_cases(self):
+        """Test edge cases for jitter calculation."""
+        # Test with attempt 0
+        attempts = 0
+        base_wait = 10
+        exponential_wait = min(base_wait * (2 ** min(attempts, 10)), 60)
+        jitter_factor = 0.1 + ((attempts % 10) * 0.02)
+        jitter = jitter_factor * exponential_wait
+        total_wait = exponential_wait + jitter
+        
+        assert total_wait > base_wait, "Total wait should be greater than base wait"
+        assert jitter_factor == 0.1, "Jitter factor should be 0.1 for attempt 0"
+        
+        # Test with very high attempt number
+        attempts = 100
+        exponential_wait = min(base_wait * (2 ** min(attempts, 10)), 60)  # Should be capped at 60
+        jitter_factor = 0.1 + ((attempts % 10) * 0.02)
+        jitter = jitter_factor * exponential_wait
+        
+        assert exponential_wait == 60, "Exponential wait should be capped at 60"
+        assert jitter_factor == 0.1, "Jitter factor should cycle back to 0.1 for attempt 100"

--- a/tests/test_suspended_nodes.py
+++ b/tests/test_suspended_nodes.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""
+Test the suspended nodes functionality.
+"""
+
+import asyncio
+import sys
+from unittest.mock import Mock, patch
+
+import pytest
+from kubernetes.client import V1Node, V1NodeSpec, V1NodeStatus, V1Pod, V1PodSpec, V1ObjectMeta, V1Taint
+
+# Configure logging
+import logging
+logging.basicConfig(level=logging.DEBUG)
+
+from rr.activities import CrateDBActivities
+from rr.models import RestartOptions
+
+
+class TestSuspendedNodesActivity:
+    """Test the is_pod_on_suspended_node activity."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.activities = CrateDBActivities()
+
+    def create_mock_pod(self, pod_name: str, node_name: str):
+        """Create a mock pod object."""
+        pod = Mock(spec=V1Pod)
+        pod.metadata = Mock(spec=V1ObjectMeta)
+        pod.metadata.name = pod_name
+        pod.spec = Mock(spec=V1PodSpec)
+        pod.spec.node_name = node_name
+        return pod
+
+    def create_mock_node(self, node_name: str, unschedulable: bool = False, taints: list = None):
+        """Create a mock node object."""
+        node = Mock(spec=V1Node)
+        node.metadata = Mock(spec=V1ObjectMeta)
+        node.metadata.name = node_name
+        node.metadata.annotations = {}
+        node.spec = Mock(spec=V1NodeSpec)
+        node.spec.unschedulable = unschedulable
+        node.spec.taints = taints or []
+        return node
+
+    def create_mock_taint(self, key: str, value: str = "true", effect: str = "NoSchedule"):
+        """Create a mock taint object."""
+        taint = Mock(spec=V1Taint)
+        taint.key = key
+        taint.value = value
+        taint.effect = effect
+        return taint
+
+    @pytest.mark.asyncio
+    async def test_pod_on_unschedulable_node(self):
+        """Test that a pod on an unschedulable node is detected as suspended."""
+        pod_name = "test-pod"
+        node_name = "test-node"
+        namespace = "test-namespace"
+
+        # Create mocks
+        mock_pod = self.create_mock_pod(pod_name, node_name)
+        mock_node = self.create_mock_node(node_name, unschedulable=True)
+
+        # Mock the kubernetes client
+        with patch.object(self.activities, '_ensure_kube_client'):
+            with patch.object(self.activities, 'core_v1') as mock_core_v1:
+                mock_core_v1.read_namespaced_pod = Mock(return_value=mock_pod)
+                mock_core_v1.read_node = Mock(return_value=mock_node)
+
+                # Test the activity
+                result = await self.activities.is_pod_on_suspended_node(pod_name, namespace)
+
+                # Verify the result
+                assert result is True
+
+    @pytest.mark.asyncio
+    async def test_pod_on_active_node(self):
+        """Test that a pod on an active node is not detected as suspended."""
+        pod_name = "test-pod"
+        node_name = "test-node"
+        namespace = "test-namespace"
+
+        # Create mocks
+        mock_pod = self.create_mock_pod(pod_name, node_name)
+        mock_node = self.create_mock_node(node_name, unschedulable=False)
+
+        # Mock the kubernetes client
+        with patch.object(self.activities, '_ensure_kube_client'):
+            with patch.object(self.activities, 'core_v1') as mock_core_v1:
+                mock_core_v1.read_namespaced_pod = Mock(return_value=mock_pod)
+                mock_core_v1.read_node = Mock(return_value=mock_node)
+
+                # Test the activity
+                result = await self.activities.is_pod_on_suspended_node(pod_name, namespace)
+
+                # Verify the result
+                assert result is False
+
+    @pytest.mark.asyncio
+    async def test_pod_on_node_with_suspension_taint(self):
+        """Test that a pod on a node with suspension taint is detected as suspended."""
+        pod_name = "test-pod"
+        node_name = "test-node"
+        namespace = "test-namespace"
+
+        # Create mocks with suspension taint
+        mock_pod = self.create_mock_pod(pod_name, node_name)
+        suspension_taint = self.create_mock_taint("node.kubernetes.io/unschedulable")
+        mock_node = self.create_mock_node(node_name, unschedulable=False, taints=[suspension_taint])
+
+        # Mock the kubernetes client
+        with patch.object(self.activities, '_ensure_kube_client'):
+            with patch.object(self.activities, 'core_v1') as mock_core_v1:
+                mock_core_v1.read_namespaced_pod = Mock(return_value=mock_pod)
+                mock_core_v1.read_node = Mock(return_value=mock_node)
+
+                # Test the activity
+                result = await self.activities.is_pod_on_suspended_node(pod_name, namespace)
+
+                # Verify the result
+                assert result is True
+
+    @pytest.mark.asyncio
+    async def test_pod_on_node_with_spot_termination_taint(self):
+        """Test that a pod on a node with spot termination taint is detected as suspended."""
+        pod_name = "test-pod"
+        node_name = "test-node"
+        namespace = "test-namespace"
+
+        # Create mocks with spot termination taint
+        mock_pod = self.create_mock_pod(pod_name, node_name)
+        spot_taint = self.create_mock_taint("aws.amazon.com/spot-instance-terminating")
+        mock_node = self.create_mock_node(node_name, unschedulable=False, taints=[spot_taint])
+
+        # Mock the kubernetes client
+        with patch.object(self.activities, '_ensure_kube_client'):
+            with patch.object(self.activities, 'core_v1') as mock_core_v1:
+                mock_core_v1.read_namespaced_pod = Mock(return_value=mock_pod)
+                mock_core_v1.read_node = Mock(return_value=mock_node)
+
+                # Test the activity
+                result = await self.activities.is_pod_on_suspended_node(pod_name, namespace)
+
+                # Verify the result
+                assert result is True
+
+    @pytest.mark.asyncio
+    async def test_pod_on_node_with_suspension_annotation(self):
+        """Test that a pod on a node with suspension annotation is detected as suspended."""
+        pod_name = "test-pod"
+        node_name = "test-node"
+        namespace = "test-namespace"
+
+        # Create mocks with suspension annotation
+        mock_pod = self.create_mock_pod(pod_name, node_name)
+        mock_node = self.create_mock_node(node_name, unschedulable=False)
+        mock_node.metadata.annotations = {"node.kubernetes.io/suspend": "true"}
+
+        # Mock the kubernetes client
+        with patch.object(self.activities, '_ensure_kube_client'):
+            with patch.object(self.activities, 'core_v1') as mock_core_v1:
+                mock_core_v1.read_namespaced_pod = Mock(return_value=mock_pod)
+                mock_core_v1.read_node = Mock(return_value=mock_node)
+
+                # Test the activity
+                result = await self.activities.is_pod_on_suspended_node(pod_name, namespace)
+
+                # Verify the result
+                assert result is True
+
+    @pytest.mark.asyncio
+    async def test_pod_with_no_node_assignment(self):
+        """Test that a pod with no node assignment is not detected as suspended."""
+        pod_name = "test-pod"
+        namespace = "test-namespace"
+
+        # Create mock pod with no node assignment
+        mock_pod = self.create_mock_pod(pod_name, None)
+        mock_pod.spec.node_name = None
+
+        # Mock the kubernetes client
+        with patch.object(self.activities, '_ensure_kube_client'):
+            with patch.object(self.activities, 'core_v1') as mock_core_v1:
+                mock_core_v1.read_namespaced_pod = Mock(return_value=mock_pod)
+
+                # Test the activity
+                result = await self.activities.is_pod_on_suspended_node(pod_name, namespace)
+
+                # Verify the result
+                assert result is False
+
+    @pytest.mark.asyncio
+    async def test_error_handling(self):
+        """Test that errors are handled gracefully."""
+        pod_name = "test-pod"
+        namespace = "test-namespace"
+
+        # Mock the kubernetes client to raise an exception
+        with patch.object(self.activities, '_ensure_kube_client'):
+            with patch.object(self.activities, 'core_v1') as mock_core_v1:
+                mock_core_v1.read_namespaced_pod = Mock(side_effect=Exception("API Error"))
+
+                # Test the activity
+                result = await self.activities.is_pod_on_suspended_node(pod_name, namespace)
+
+                # Verify the result defaults to False on error
+                assert result is False
+
+
+class TestRestartOptionsModel:
+    """Test the RestartOptions model with the new field."""
+
+    def test_restart_options_default_values(self):
+        """Test that RestartOptions has correct default values."""
+        options = RestartOptions()
+        
+        assert options.only_on_suspended_nodes is False
+        assert options.dry_run is False
+        assert options.skip_hook_warning is False
+
+    def test_restart_options_with_suspended_nodes_flag(self):
+        """Test RestartOptions with suspended nodes flag enabled."""
+        options = RestartOptions(
+            only_on_suspended_nodes=True,
+            context="test-context"
+        )
+        
+        assert options.only_on_suspended_nodes is True
+        assert options.context == "test-context"
+
+    def test_restart_options_serialization(self):
+        """Test that RestartOptions can be serialized and deserialized."""
+        original_options = RestartOptions(
+            only_on_suspended_nodes=True,
+            context="test-context",
+            dry_run=True
+        )
+        
+        # Test conversion to dict
+        options_dict = original_options.model_dump()
+        assert options_dict["only_on_suspended_nodes"] is True
+        assert options_dict["context"] == "test-context"
+        assert options_dict["dry_run"] is True
+        
+        # Test reconstruction from dict
+        reconstructed_options = RestartOptions(**options_dict)
+        assert reconstructed_options.only_on_suspended_nodes is True
+        assert reconstructed_options.context == "test-context"
+        assert reconstructed_options.dry_run is True
+
+
+if __name__ == "__main__":
+    # Run the tests
+    pytest.main([__file__, "-v"])

--- a/tests/test_suspended_nodes_integration.py
+++ b/tests/test_suspended_nodes_integration.py
@@ -1,0 +1,373 @@
+#!/usr/bin/env python3
+"""
+Integration test example for the suspended nodes feature.
+
+This test demonstrates how the --only-on-suspended-nodes flag works
+in practice with realistic scenarios.
+"""
+
+import asyncio
+import sys
+from unittest.mock import Mock, patch, MagicMock
+from datetime import datetime, timedelta
+
+import pytest
+from kubernetes.client import V1Node, V1NodeSpec, V1Pod, V1PodSpec, V1ObjectMeta, V1Taint
+
+# Configure logging
+import logging
+logging.basicConfig(level=logging.INFO)
+
+from rr.activities import CrateDBActivities
+from rr.models import (
+    CrateDBCluster, 
+    RestartOptions, 
+    MultiClusterRestartInput,
+    ClusterDiscoveryInput
+)
+from rr.state_machines import ClusterRestartStateMachine
+
+
+class TestSuspendedNodesIntegration:
+    """Integration tests for the suspended nodes feature."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.activities = CrateDBActivities()
+
+    def create_test_cluster(self, name: str, pods: list, namespace: str = "default"):
+        """Create a test cluster with the specified pods."""
+        return CrateDBCluster(
+            name=name,
+            namespace=namespace,
+            statefulset_name=f"{name}-sts",
+            health="GREEN",
+            replicas=len(pods),
+            pods=pods,
+            has_prestop_hook=True,
+            has_dc_util=True,
+            suspended=False,
+            crd_name=f"{name}-crd",
+            dc_util_timeout=720,
+            min_availability="PRIMARIES"
+        )
+
+    def create_mock_pod(self, pod_name: str, node_name: str):
+        """Create a mock pod running on the specified node."""
+        pod = Mock(spec=V1Pod)
+        pod.metadata = Mock(spec=V1ObjectMeta)
+        pod.metadata.name = pod_name
+        pod.spec = Mock(spec=V1PodSpec)
+        pod.spec.node_name = node_name
+        return pod
+
+    def create_mock_node(self, node_name: str, is_suspended: bool = False, 
+                        suspension_reason: str = "unschedulable"):
+        """Create a mock node with suspension status."""
+        node = Mock(spec=V1Node)
+        node.metadata = Mock(spec=V1ObjectMeta)
+        node.metadata.name = node_name
+        node.metadata.annotations = {}
+        node.spec = Mock(spec=V1NodeSpec)
+        node.spec.taints = []
+        
+        if is_suspended:
+            if suspension_reason == "unschedulable":
+                node.spec.unschedulable = True
+            elif suspension_reason == "spot_terminating":
+                node.spec.unschedulable = False
+                taint = Mock(spec=V1Taint)
+                taint.key = "aws.amazon.com/spot-instance-terminating"
+                taint.value = "true"
+                taint.effect = "NoSchedule"
+                node.spec.taints = [taint]
+            elif suspension_reason == "annotation":
+                node.spec.unschedulable = False
+                node.metadata.annotations = {"node.kubernetes.io/suspend": "true"}
+        else:
+            node.spec.unschedulable = False
+            
+        return node
+
+    @pytest.mark.asyncio
+    async def test_mixed_node_scenario(self):
+        """Test scenario with mixed active and suspended nodes."""
+        # Create a cluster with 4 pods on different nodes
+        cluster = self.create_test_cluster(
+            name="test-cluster",
+            pods=["pod-0", "pod-1", "pod-2", "pod-3"],
+            namespace="cratedb"
+        )
+        
+        # Create options with suspended nodes only
+        options = RestartOptions(
+            context="test-context",
+            only_on_suspended_nodes=True,
+            dry_run=True,  # Use dry run for testing
+            log_level="DEBUG"
+        )
+        
+        # Mock the pod-to-node mapping
+        pod_node_mapping = {
+            "pod-0": ("worker-1", False),     # Active node
+            "pod-1": ("worker-2", True),      # Suspended node (unschedulable)
+            "pod-2": ("worker-3", False),     # Active node
+            "pod-3": ("worker-4", True),      # Suspended node (spot terminating)
+        }
+        
+        # Mock the kubernetes client calls
+        with patch.object(self.activities, '_ensure_kube_client'):
+            with patch.object(self.activities, 'core_v1') as mock_core_v1:
+                
+                def mock_read_pod(name, namespace):
+                    node_name, _ = pod_node_mapping[name]
+                    return self.create_mock_pod(name, node_name)
+                
+                def mock_read_node(name):
+                    for pod_name, (node_name, is_suspended) in pod_node_mapping.items():
+                        if node_name == name:
+                            reason = "spot_terminating" if name == "worker-4" else "unschedulable"
+                            return self.create_mock_node(node_name, is_suspended, reason)
+                    return self.create_mock_node(name, False)
+                
+                mock_core_v1.read_namespaced_pod.side_effect = mock_read_pod
+                mock_core_v1.read_node.side_effect = mock_read_node
+                
+                # Test node suspension detection for each pod
+                results = {}
+                for pod_name in cluster.pods:
+                    result = await self.activities.is_pod_on_suspended_node(pod_name, cluster.namespace)
+                    results[pod_name] = result
+                
+                # Verify results
+                expected_results = {
+                    "pod-0": False,  # Active node
+                    "pod-1": True,   # Suspended node
+                    "pod-2": False,  # Active node
+                    "pod-3": True,   # Suspended node
+                }
+                
+                assert results == expected_results, f"Expected {expected_results}, got {results}"
+                
+                # Count suspended vs active
+                suspended_pods = [pod for pod, suspended in results.items() if suspended]
+                active_pods = [pod for pod, suspended in results.items() if not suspended]
+                
+                assert len(suspended_pods) == 2, f"Expected 2 suspended pods, got {len(suspended_pods)}"
+                assert len(active_pods) == 2, f"Expected 2 active pods, got {len(active_pods)}"
+                assert suspended_pods == ["pod-1", "pod-3"]
+                assert active_pods == ["pod-0", "pod-2"]
+
+    @pytest.mark.asyncio
+    async def test_all_nodes_suspended_scenario(self):
+        """Test scenario where all nodes are suspended."""
+        cluster = self.create_test_cluster(
+            name="test-cluster",
+            pods=["pod-0", "pod-1", "pod-2"],
+            namespace="cratedb"
+        )
+        
+        # All nodes are suspended
+        pod_node_mapping = {
+            "pod-0": ("worker-1", True),
+            "pod-1": ("worker-2", True),
+            "pod-2": ("worker-3", True),
+        }
+        
+        with patch.object(self.activities, '_ensure_kube_client'):
+            with patch.object(self.activities, 'core_v1') as mock_core_v1:
+                
+                def mock_read_pod(name, namespace):
+                    node_name, _ = pod_node_mapping[name]
+                    return self.create_mock_pod(name, node_name)
+                
+                def mock_read_node(name):
+                    return self.create_mock_node(name, True, "unschedulable")
+                
+                mock_core_v1.read_namespaced_pod.side_effect = mock_read_pod
+                mock_core_v1.read_node.side_effect = mock_read_node
+                
+                # Test all pods
+                results = {}
+                for pod_name in cluster.pods:
+                    result = await self.activities.is_pod_on_suspended_node(pod_name, cluster.namespace)
+                    results[pod_name] = result
+                
+                # All should be suspended
+                assert all(results.values()), f"All pods should be suspended, got {results}"
+
+    @pytest.mark.asyncio
+    async def test_no_nodes_suspended_scenario(self):
+        """Test scenario where no nodes are suspended."""
+        cluster = self.create_test_cluster(
+            name="test-cluster",
+            pods=["pod-0", "pod-1", "pod-2"],
+            namespace="cratedb"
+        )
+        
+        # No nodes are suspended
+        pod_node_mapping = {
+            "pod-0": ("worker-1", False),
+            "pod-1": ("worker-2", False),
+            "pod-2": ("worker-3", False),
+        }
+        
+        with patch.object(self.activities, '_ensure_kube_client'):
+            with patch.object(self.activities, 'core_v1') as mock_core_v1:
+                
+                def mock_read_pod(name, namespace):
+                    node_name, _ = pod_node_mapping[name]
+                    return self.create_mock_pod(name, node_name)
+                
+                def mock_read_node(name):
+                    return self.create_mock_node(name, False)
+                
+                mock_core_v1.read_namespaced_pod.side_effect = mock_read_pod
+                mock_core_v1.read_node.side_effect = mock_read_node
+                
+                # Test all pods
+                results = {}
+                for pod_name in cluster.pods:
+                    result = await self.activities.is_pod_on_suspended_node(pod_name, cluster.namespace)
+                    results[pod_name] = result
+                
+                # None should be suspended
+                assert not any(results.values()), f"No pods should be suspended, got {results}"
+
+    @pytest.mark.asyncio
+    async def test_restart_options_flag_behavior(self):
+        """Test that the RestartOptions flag works correctly."""
+        
+        # Test default behavior (flag disabled)
+        options_default = RestartOptions(context="test")
+        assert options_default.only_on_suspended_nodes is False
+        
+        # Test with flag enabled
+        options_enabled = RestartOptions(context="test", only_on_suspended_nodes=True)
+        assert options_enabled.only_on_suspended_nodes is True
+        
+        # Test serialization/deserialization
+        options_dict = options_enabled.model_dump()
+        options_restored = RestartOptions(**options_dict)
+        assert options_restored.only_on_suspended_nodes is True
+
+    def test_suspension_detection_criteria(self):
+        """Test different suspension detection criteria."""
+        
+        # Test unschedulable node
+        node_unschedulable = self.create_mock_node("node1", True, "unschedulable")
+        assert node_unschedulable.spec.unschedulable is True
+        
+        # Test spot terminating node
+        node_spot = self.create_mock_node("node2", True, "spot_terminating")
+        assert node_spot.spec.unschedulable is False
+        assert len(node_spot.spec.taints) == 1
+        assert node_spot.spec.taints[0].key == "aws.amazon.com/spot-instance-terminating"
+        
+        # Test annotation-based suspension
+        node_annotation = self.create_mock_node("node3", True, "annotation")
+        assert node_annotation.spec.unschedulable is False
+        assert "node.kubernetes.io/suspend" in node_annotation.metadata.annotations
+        
+        # Test active node
+        node_active = self.create_mock_node("node4", False)
+        assert node_active.spec.unschedulable is False
+        assert len(node_active.spec.taints) == 0
+        assert len(node_active.metadata.annotations) == 0
+
+    @pytest.mark.asyncio
+    async def test_error_handling_graceful_degradation(self):
+        """Test that errors are handled gracefully."""
+        
+        cluster = self.create_test_cluster(
+            name="test-cluster",
+            pods=["pod-0"],
+            namespace="cratedb"
+        )
+        
+        with patch.object(self.activities, '_ensure_kube_client'):
+            with patch.object(self.activities, 'core_v1') as mock_core_v1:
+                
+                # Mock API error
+                mock_core_v1.read_namespaced_pod.side_effect = Exception("Kubernetes API error")
+                
+                # Should return False (safe default) on error
+                result = await self.activities.is_pod_on_suspended_node("pod-0", cluster.namespace)
+                assert result is False
+
+    def test_real_world_scenarios(self):
+        """Test configuration for real-world scenarios."""
+        
+        # Spot instance termination scenario
+        spot_options = RestartOptions(
+            context="prod",
+            only_on_suspended_nodes=True,
+            dry_run=False,
+            log_level="INFO"
+        )
+        
+        # Maintenance window scenario
+        maintenance_options = RestartOptions(
+            context="prod",
+            only_on_suspended_nodes=True,
+            dry_run=True,  # Test first
+            maintenance_config_path="/etc/maintenance.toml",
+            log_level="DEBUG"
+        )
+        
+        # Emergency scenario
+        emergency_options = RestartOptions(
+            context="prod",
+            only_on_suspended_nodes=True,
+            ignore_maintenance_windows=True,
+            skip_hook_warning=True,
+            log_level="INFO"
+        )
+        
+        # Verify configurations
+        assert spot_options.only_on_suspended_nodes is True
+        assert maintenance_options.only_on_suspended_nodes is True
+        assert emergency_options.only_on_suspended_nodes is True
+        assert emergency_options.ignore_maintenance_windows is True
+
+
+class TestSuspendedNodesDocumentation:
+    """Test that the feature is properly documented."""
+    
+    def test_cli_help_includes_flag(self):
+        """Test that CLI help includes the new flag."""
+        # This would be tested by running the CLI help command
+        # and verifying the flag appears in the output
+        pass
+    
+    def test_documentation_examples(self):
+        """Test that documentation examples are valid."""
+        # Verify that the examples in the documentation are syntactically correct
+        
+        # Example 1: Basic usage
+        options1 = RestartOptions(
+            context="prod",
+            only_on_suspended_nodes=True
+        )
+        assert options1.only_on_suspended_nodes is True
+        
+        # Example 2: With dry run
+        options2 = RestartOptions(
+            context="prod", 
+            only_on_suspended_nodes=True,
+            dry_run=True
+        )
+        assert options2.only_on_suspended_nodes is True
+        assert options2.dry_run is True
+        
+        # Example 3: With async
+        options3 = RestartOptions(
+            context="prod",
+            only_on_suspended_nodes=True
+        )
+        assert options3.only_on_suspended_nodes is True
+
+
+if __name__ == "__main__":
+    # Run the tests
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
The commit adds a new `--only-on-suspended-nodes` feature that allows selective restart of CrateDB pods running on suspended Kubernetes nodes, with comprehensive test coverage.

A node is considered suspended if it has any of: - `spec.unschedulable: true` - Suspension taints like `node.kubernetes.io/unschedulable` - Suspension annotations like `node.kubernetes.io/suspend`

The changes include: - New activity for checking node suspension status
- CLI flag and RestartOptions model updates - State machine integration for pod selection - Comprehensive test suites - Detailed documentation - Demo script for feature walkthrough

⚠️ Worker restart required for new activity registration.